### PR TITLE
Prepare to AgroLD v2.0.0

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -39,7 +39,9 @@ jobs:
 
     - name: Get short commit hash
       id: variables
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      run: |
+        echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "build_date=$(date --rfc-3339=ns)" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -57,6 +59,15 @@ jobs:
         registry: ${{ vars.DOCKER_REGISTRY_HOST }}
         username: ${{ secrets.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+    
+    - name: Set version and build date
+      uses: actions/github-script@v4
+      id: set_version
+      with:
+        script: |
+          const build_date = new Date().toISOString()
+          core.setOutput('build_date', build_date)
+
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
@@ -65,8 +76,9 @@ jobs:
           AGROLD_NAME=agrolddev
           AGROLD_DESCRIPTION="agrold development instance generated from commit ${GIT_COMMIT}"
           GIT_COMMIT=${{ steps.variables.outputs.sha_short }}
+          BUILD_DATE=${{ steps.variables.outputs.build_date }}
         allow: security.insecure # Activated because docker does not like self-signed certificates
         push: true
         context: ./agrold-javaweb
         file: ./agrold-javaweb/Dockerfile
-        tags: ${{ vars.DOCKER_REGISTRY_HOST }}/agrold:${{ steps.variables.outputs.sha_short }},${{ vars.DOCKER_REGISTRY_HOST }}/agrold:latest
+        tags: ${{ vars.DOCKER_REGISTRY_HOST }}/agrolddev:${{ steps.variables.outputs.sha_short }},${{ vars.DOCKER_REGISTRY_HOST }}/agrolddev:latest

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -14,6 +14,9 @@ on:
 # This workflow will build a docker container, publish it to our private registry
 # tagged as latest and with latest commit hash (shortened)
 jobs:
+  test_helm:
+    uses: ./.github/workflows/test_helm_chart.yaml
+
   build:
     runs-on: self-hosted
     

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -1,6 +1,7 @@
-name: Push to dev environment
+name: Push to dev 👷‍♂️
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - dev
@@ -9,12 +10,20 @@ on:
       - agrold-javaweb/src/**
       - agrold-javaweb/pom.xml
       - agrold-javaweb/Dockerfile
-      
+
 # This workflow will build a docker container, publish it to our private registry
 # tagged as latest and with latest commit hash (shortened)
 jobs:
   build:
     runs-on: self-hosted
+    
+    env: 
+      IMAGENAME: agrolddev
+
+    outputs:
+      BUILD_DATE: ${{ steps.variables.outputs.build_date }}
+      GIT_COMMIT: ${{ steps.variables.outputs.sha_short }}
+      NAME: ${{ env.IMAGENAME }}
 
     steps:
     - name: Clone project
@@ -43,42 +52,16 @@ jobs:
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         echo "build_date=$(date --rfc-3339=ns)" >> $GITHUB_OUTPUT
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        version: latest
-        config-inline: |
-            [registry."${{ vars.DOCKER_REGISTRY_HOST }}"]
-              http = false
-              insecure = true
-              ca=["/etc/docker/certs.d/10.9.2.21/ca.crt"]
-
-    - name: "Login to private registry at: ${{ vars.DOCKER_REGISTRY_HOST }}"
-      uses: docker/login-action@v2.1.0
-      with:
-        registry: ${{ vars.DOCKER_REGISTRY_HOST }}
-        username: ${{ secrets.DOCKER_REGISTRY_USER }}
-        password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
-    
-    - name: Set version and build date
-      uses: actions/github-script@v4
-      id: set_version
-      with:
-        script: |
-          const build_date = new Date().toISOString()
-          core.setOutput('build_date', build_date)
-
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v4
-      with:
-        build-args: |
-          AGROLD_NAME=agrolddev
-          AGROLD_DESCRIPTION="agrold development instance generated from commit ${GIT_COMMIT}"
-          GIT_COMMIT=${{ steps.variables.outputs.sha_short }}
-          BUILD_DATE=${{ steps.variables.outputs.build_date }}
-        allow: security.insecure # Activated because docker does not like self-signed certificates
-        push: true
-        context: ./agrold-javaweb
-        file: ./agrold-javaweb/Dockerfile
-        tags: ${{ vars.DOCKER_REGISTRY_HOST }}/agrolddev:${{ steps.variables.outputs.sha_short }},${{ vars.DOCKER_REGISTRY_HOST }}/agrolddev:latest
+  build_n_push_private:
+    needs: build
+    uses: ./.github/workflows/push_to_private.yml
+    with:
+      build-args: AGROLD_NAME=${{ needs.build.outputs.NAME }} AGROLD_DESCRIPTION="Agrold from commit ${{ needs.build.outputs.GIT_COMMIT }}" GIT_COMMIT=${{ needs.build.outputs.GIT_COMMIT}} BUILD_DATE="${{ needs.build.outputs.BUILD_DATE }}"
+      context: ./agrold-javaweb
+      dockerfile: ./agrold-javaweb/Dockerfile
+      image_name: agrolddev
+      tag: ${{ needs.build.outputs.GIT_COMMIT }}
+      registry_host: "10.9.2.21:8080"
+    secrets: 
+      DOCKER_REGISTRY_USER:     ${{ secrets.DOCKER_REGISTRY_USER }}
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -56,7 +56,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/push_to_private.yml
     with:
-      build-args: AGROLD_NAME=${{ needs.build.outputs.NAME }} AGROLD_DESCRIPTION="Agrold from commit ${{ needs.build.outputs.GIT_COMMIT }}" GIT_COMMIT=${{ needs.build.outputs.GIT_COMMIT}} BUILD_DATE="${{ needs.build.outputs.BUILD_DATE }}"
+      build-args: AGROLD_NAME=${{ needs.build.outputs.NAME }},AGROLD_DESCRIPTION="Agrold from commit ${{ needs.build.outputs.GIT_COMMIT }}",GIT_COMMIT=${{ needs.build.outputs.GIT_COMMIT}},BUILD_DATE="${{ needs.build.outputs.BUILD_DATE }}"
       context: ./agrold-javaweb
       dockerfile: ./agrold-javaweb/Dockerfile
       image_name: agrolddev

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -86,7 +86,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/push_to_private.yml
     with:
-      build-args: AGROLD_NAME=agrold AGROLD_DESCRIPTION="Agrold from version ${{ needs.build.outputs.no_v }}, commit ${{ needs.build.outputs.sha_short }}" GIT_COMMIT=${{ needs.build.outputs.no_v }} BUILD_DATE="${{ needs.build.outputs.build_date }}"
+      build-args: AGROLD_NAME=agrold,AGROLD_DESCRIPTION="Agrold from version ${{ needs.build.outputs.no_v }} commit ${{ needs.build.outputs.sha_short }}",GIT_COMMIT=${{ needs.build.outputs.no_v }},BUILD_DATE="${{ needs.build.outputs.build_date }}"
       context: ./agrold-javaweb
       dockerfile: ./agrold-javaweb/Dockerfile
       image_name: agrolddev

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: Push to dev environment
+name: Push to production ☁️
 
 on:
   push:
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    outputs:
+      sha_short:  ${{ steps.variables.outputs.sha_short }}
+      build_date: ${{ steps.variables.outputs.build_date }}
+      no_v:       ${{ steps.set_version.outputs.no_v }}
 
     steps:
     - name: Clone project
@@ -45,6 +50,13 @@ jobs:
           const no_v = tag.replace('v', '')
           core.setOutput('no_v', no_v)
     
+  build_n_push_prod:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
@@ -63,9 +75,23 @@ jobs:
         build-args: |
           AGROLD_NAME=agrold
           AGROLD_DESCRIPTION="agrold production instance"
-          GIT_COMMIT=${{ steps.set_version.outputs.no_v }}
-          BUILD_DATE=${{ steps.variables.outputs.build_date }}
+          GIT_COMMIT=${{ needs.build.outputs.sha_short }}
+          BUILD_DATE=${{ needs.build.outputs.build_date }}
         push: true
         context: ./agrold-javaweb
         file: ./agrold-javaweb/Dockerfile
-        tags: ghcr.io/southgreenplatform/agrold:${{ steps.set_version.outputs.no_v }},ghcr.io/southgreenplatform/agrold:latest
+        tags: ghcr.io/southgreenplatform/agrold:${{ needs.build.outputs.no_v }},ghcr.io/southgreenplatform/agrold:latest
+
+  build_n_push_private:
+    needs: build
+    uses: ./.github/workflows/push_to_private.yml
+    with:
+      build-args: AGROLD_NAME=agrold AGROLD_DESCRIPTION="Agrold from version ${{ needs.build.outputs.no_v }}, commit ${{ needs.build.outputs.sha_short }}" GIT_COMMIT=${{ needs.build.outputs.no_v }} BUILD_DATE="${{ needs.build.outputs.build_date }}"
+      context: ./agrold-javaweb
+      dockerfile: ./agrold-javaweb/Dockerfile
+      image_name: agrolddev
+      tag: ${{ needs.build.outputs.no_v }}
+      registry_host: "10.9.2.21:8080"
+    secrets: 
+      DOCKER_REGISTRY_USER:     ${{ secrets.DOCKER_REGISTRY_USER }}
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,21 @@ jobs:
   test_helm:
     uses: ./.github/workflows/test_helm_chart.yaml
 
+  publish_helm:
+    needs: test_helm
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.6.0
+      env:
+        CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      with:
+        mark_as_latest: true
+        skip_existing: true
+        charts_dir: ./agrold-javaweb/charts
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,6 +6,9 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
       
 jobs:
+  test_helm:
+    uses: ./.github/workflows/test_helm_chart.yaml
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,7 +32,9 @@ jobs:
 
     - name: Get short commit hash
       id: variables
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      run: |
+        echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "build_date=$(date --rfc-3339=ns)" >> $GITHUB_OUTPUT
 
     - name: Set Versions
       uses: actions/github-script@v4
@@ -42,8 +44,7 @@ jobs:
           const tag = context.ref.substring(10)
           const no_v = tag.replace('v', '')
           core.setOutput('no_v', no_v)
-
-
+    
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
@@ -62,7 +63,8 @@ jobs:
         build-args: |
           AGROLD_NAME=agrold
           AGROLD_DESCRIPTION="agrold production instance"
-          GIT_COMMIT=${{ steps.variables.outputs.sha_short }}
+          GIT_COMMIT=${{ steps.set_version.outputs.no_v }}
+          BUILD_DATE=${{ steps.variables.outputs.build_date }}
         push: true
         context: ./agrold-javaweb
         file: ./agrold-javaweb/Dockerfile

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,69 @@
+name: Push to dev environment
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone project
+      uses: actions/checkout@v3
+
+    # =============================
+    # This will be activated later
+    # =============================
+
+    # - name : Set up JDK 11
+    #   uses: actions/setup-java@v2
+    #   with:
+    #     java-version: '11'
+    #     distribution: 'adopt'
+    #     cache: 'maven' 
+
+    # - name: install dependencies
+    #   run: mvn install -DskipTests
+
+    # - name: Run JUNIT tests
+    #   run: mvn test
+
+    - name: Get short commit hash
+      id: variables
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Set Versions
+      uses: actions/github-script@v4
+      id: set_version
+      with:
+        script: |
+          const tag = context.ref.substring(10)
+          const no_v = tag.replace('v', '')
+          core.setOutput('no_v', no_v)
+
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        version: latest
+        
+    - name: Login to ghcr.io
+      uses: docker/login-action@v2.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        build-args: |
+          AGROLD_NAME=agrold
+          AGROLD_DESCRIPTION="agrold production instance"
+          GIT_COMMIT=${{ steps.variables.outputs.sha_short }}
+        push: true
+        context: ./agrold-javaweb
+        file: ./agrold-javaweb/Dockerfile
+        tags: ghcr.io/southgreenplatform/agrold:${{ steps.set_version.outputs.no_v }},ghcr.io/southgreenplatform/agrold:latest

--- a/.github/workflows/push_to_private.yml
+++ b/.github/workflows/push_to_private.yml
@@ -1,0 +1,85 @@
+name: Push container to private registry
+
+on:
+  workflow_call: 
+    inputs:
+      build-args:
+        type: string
+        default: ""
+        description: Build args to pass to docker build A=a B=b ...
+        required: false
+      image_name:
+        type: string
+        description: Image name to push to registry (w/o tag and host)
+        required: true
+      tag:
+        type: string
+        description: Tag to push to registry
+        required: true
+      context:
+        type: string
+        default: "."
+        description: Context to build from
+        required: true
+      dockerfile:
+        type: string
+        default: ${{ inputs.context }}/Dockerfile
+        description: Dockerfile to build
+      registry_host:
+        type: string
+        description: Docker registry host
+        required: false
+        default: "10.9.2.21:8080"
+    secrets:
+      DOCKER_REGISTRY_USER:
+        description: Docker username
+        required: true
+      DOCKER_REGISTRY_PASSWORD:
+        description: Docker password
+        required: true
+
+
+run-name: Push ${{ github.repository }} to private registry with tag ${{ inputs.tag}}
+
+jobs:
+  job:
+    runs-on: self-hosted
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize build args
+        id: normalize_build_args
+        # the input.build-args is a string line in the form A=a,B=b c,D=d,... we want to convert it to a list of strings
+        run: |
+          args="$(echo "${{ inputs.build-args }}" | tr ',' '\n'"
+          echo "args=$args" >> $GITHUB_OUTPUT
+          echo "host_wo_port=$(echo "${{ inputs.registry_host }}" | cut -d: -f1 )" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: latest
+          config-inline: |
+              [registry."${{ inputs.registry_host }}"]
+                http = false
+                insecure = true
+                ca=["/etc/docker/certs.d/${{ steps.normalize_build_args.outputs.host_wo_port }}/ca.crt"]
+
+      - name: "Login to private registry at: ${{ inputs.registry_host }}"
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ inputs.registry_host }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            ${{ steps.normalize_build_args.outputs.args }}
+          allow: security.insecure # Activated because docker does not like self-signed certificates
+          push: true
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          tags: ${{ inputs.registry_host }}/${{ inputs.image_name }}:${{ inputs.tag }},${{ inputs.registry_host }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/push_to_private.yml
+++ b/.github/workflows/push_to_private.yml
@@ -52,7 +52,7 @@ jobs:
         id: normalize_build_args
         # the input.build-args is a string line in the form A=a,B=b c,D=d,... we want to convert it to a list of strings
         run: |
-          args="$(echo "${{ inputs.build-args }}" | tr ',' '\n'"
+          args="$(echo '${{ inputs.build-args }}' | tr ',' '\n')"
           echo "args=$args" >> $GITHUB_OUTPUT
           echo "host_wo_port=$(echo "${{ inputs.registry_host }}" | cut -d: -f1 )" >> $GITHUB_OUTPUT
 
@@ -73,11 +73,10 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image ${{ inputs.registry_host }}/${{ inputs.image_name }}:${{ inputs.tag }}
         uses: docker/build-push-action@v4
         with:
-          build-args: |
-            ${{ steps.normalize_build_args.outputs.args }}
+          build-args: ${{ steps.normalize_build_args.outputs.args }}
           allow: security.insecure # Activated because docker does not like self-signed certificates
           push: true
           context: ${{ inputs.context }}

--- a/.github/workflows/test_helm_chart.yaml
+++ b/.github/workflows/test_helm_chart.yaml
@@ -8,6 +8,9 @@ run-name: Test Helm Chart
 jobs:
   job:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        helm-charts: [agrold-javaweb, virtuoso]
 
     steps:
       - uses: actions/checkout@v3
@@ -18,8 +21,8 @@ jobs:
       - name: Helm Check Action
         uses: hopisaurus/helm-check-action@v0.1.0
         env:
-          CHART_LOCATION: ./agrold-javaweb/charts/agrold-javaweb
-          CHART_VALUES: ./agrold-javaweb/charts/agrold-javaweb/values.yaml
+          CHART_LOCATION: ./agrold-javaweb/charts/${{ matrix.helm-charts }}
+          CHART_VALUES: ./agrold-javaweb/charts/${{ matrix.helm-charts }}/values.yaml
         with:
-          chart-location: ./agrold-javaweb/charts/agrold-javaweb
-          chart-values: ./agrold-javaweb/charts/agrold-javaweb/values.yaml
+          chart-location: ./agrold-javaweb/charts/${{ matrix.helm-charts }}
+          chart-values: ./agrold-javaweb/charts/${{ matrix.helm-charts }}/values.yaml

--- a/.github/workflows/test_helm_chart.yaml
+++ b/.github/workflows/test_helm_chart.yaml
@@ -1,0 +1,25 @@
+name: Test Helm chart
+
+on:
+  workflow_call:
+
+run-name: Test Helm Chart
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Helm Check Action
+        uses: hopisaurus/helm-check-action@v0.1.0
+        env:
+          CHART_LOCATION: ./agrold-javaweb/charts/agrold-javaweb
+          CHART_VALUES: ./agrold-javaweb/charts/agrold-javaweb/values.yaml
+        with:
+          chart-location: ./agrold-javaweb/charts/agrold-javaweb
+          chart-values: ./agrold-javaweb/charts/agrold-javaweb/values.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target/
 .idea/
 *.iml
 *.vscode/
+nbactions.xml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For bug tracking purpose you can use the GitHub or questions about AgroLG, you c
 
 * nordine.elhassouni_at_cirad.fr
 * pierre.larmande_at_ird.fr
+* yann.pomie_at_ird.fr
 
 
 # Valorization

--- a/agrold-javaweb/.vscode.template/settings.json
+++ b/agrold-javaweb/.vscode.template/settings.json
@@ -1,0 +1,9 @@
+{
+  "maven.terminal.favorites": [
+    {
+      "command": "package docker:build docker:start docker:watch",
+      "debug": false,
+      "alias": "Run in container"
+    }
+  ]
+}

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -1,12 +1,8 @@
 # Build stage
 FROM maven:3.9-amazoncorretto-8 as build
 # Shared arguments between build and run stages
-ARG GIT_COMMIT=unknown
 
 ARG AGROLD_NAME=aldp
-
-# This is here so we can change it depending of dev/prod
-ENV AGROLD_NAME=${AGROLD_NAME}
 
 WORKDIR /build_dir
 
@@ -17,12 +13,14 @@ RUN mvn clean install -Dagrold.name=${AGROLD_NAME}
 # Run stage
 FROM bitnami/tomcat:7
 
-# We renew arguments
-ARG GIT_COMMIT
-ARG AGROLD_NAME
+ARG GIT_COMMIT=unknown
+ARG AGROLD_NAME=aldp
+
+# This is here so we can change it depending of dev/prod
+ENV NAME=${AGROLD_NAME}
 
 ARG BUILD_DATE=unknown
-ARG AGROLD_DESCRIPTION='"agrold production instance generated from commit ${GIT_COMMIT}"'
+ARG AGROLD_DESCRIPTION='"agrold production instance"'
 
 LABEL "fr.ird.maintainer"="Yann POMIE <yann.pomie@ird.fr>" \
       "version"=${GIT_COMMIT} \
@@ -32,7 +30,7 @@ LABEL "fr.ird.maintainer"="Yann POMIE <yann.pomie@ird.fr>" \
       "org.opencontainers.image.source"="https://github.com/SouthGreenPlatform/AgroLD_webapp" \
       "org.opencontainers.image.version"=${GIT_COMMIT}   
 
-COPY --from=build /build_dir/target/${AGROLD_NAME}.war /opt/bitnami/tomcat/webapps_default
+COPY --from=build /build_dir/target/*.war /opt/bitnami/tomcat/webapps_default
 
 ENV GIT_COMMIT=${GIT_COMMIT}
-ENV JAVA_OPTS="-Dagrold.name=${AGROLD_NAME} -Dagrold.description=${AGROLD_DESCRIPTION}" 
+ENV JAVA_OPTS="-Dagrold.name=${NAME} -Dagrold.description=${AGROLD_DESCRIPTION}" 

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.9-amazoncorretto-8 as build
 # Shared arguments between build and run stages
 ARG GIT_COMMIT=unknown
 
-ARG AGROLD_NAME=agrold
+ARG AGROLD_NAME=aldp
 
 # This is here so we can change it depending of dev/prod
 ENV AGROLD_NAME=${AGROLD_NAME}
@@ -12,7 +12,7 @@ WORKDIR /build_dir
 
 COPY . /build_dir
 
-RUN AGROLD_NAME=${AGROLD_NAME} mvn clean install
+RUN mvn clean install -Dagrold.name=${AGROLD_NAME}
 
 # Run stage
 FROM bitnami/tomcat:7

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -4,7 +4,6 @@ FROM maven:3.9-amazoncorretto-8 as build
 ARG GIT_COMMIT=unknown
 
 ARG AGROLD_NAME=agrold
-ARG AGROLD_DESCRIPTION=agrold production instance generated from commit ${GIT_COMMIT}
 
 # This is here so we can change it depending of dev/prod
 ENV AGROLD_NAME=${AGROLD_NAME}
@@ -21,9 +20,9 @@ FROM bitnami/tomcat:7
 # We renew arguments
 ARG GIT_COMMIT
 ARG AGROLD_NAME
-ARG AGROLD_DESCRIPTION
 
 ARG BUILD_DATE=unknown
+ARG AGROLD_DESCRIPTION='"agrold production instance generated from commit ${GIT_COMMIT}"'
 
 LABEL "fr.ird.maintainer"="Yann POMIE <yann.pomie@ird.fr>" \
       "version"=${GIT_COMMIT} \

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -11,10 +11,6 @@ ENV AGROLD_NAME=${AGROLD_NAME}
 
 WORKDIR /build_dir
 
-LABEL "fr.ird.maintainer"="Yann POMIE <yann.pomie@ird.fr>" \
-      "version"=${GIT_COMMIT} \
-      "description"=${AGROLD_DESCRIPTION}
-
 COPY . /build_dir
 
 RUN AGROLD_NAME=${AGROLD_NAME} mvn clean install
@@ -27,7 +23,16 @@ ARG GIT_COMMIT
 ARG AGROLD_NAME
 ARG AGROLD_DESCRIPTION
 
-# COPY --from=build /build_dir/target/${AGROLD_NAME}.war /opt/bitnami/tomcat/webapps
+ARG BUILD_DATE=unknown
+
+LABEL "fr.ird.maintainer"="Yann POMIE <yann.pomie@ird.fr>" \
+      "version"=${GIT_COMMIT} \
+      "description"=${AGROLD_DESCRIPTION} \
+      "org.opencontainers.image.authors"="Yann POMIE <yann.pomie@ird.fr>" \
+      "org.opencontainers.image.created"=${BUILD_DATE} \
+      "org.opencontainers.image.source"="https://github.com/SouthGreenPlatform/AgroLD_webapp" \
+      "org.opencontainers.image.version"=${GIT_COMMIT}   
+
 COPY --from=build /build_dir/target/${AGROLD_NAME}.war /opt/bitnami/tomcat/webapps_default
 
 ENV GIT_COMMIT=${GIT_COMMIT}

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -1,4 +1,6 @@
-![Static Badge](https://img.shields.io/badge/Read_our_Wiki_on_Notion-_?style=for-the-badge&logo=notion&logoColor=white&color=86B817&link=https%3A%2F%2Fagrold-wiki.notion.site%2FWiki-AgroLD-2db695645df945e693b9d8ad3244e7bc)
+[![WIKI]](https://agrold-wiki.notion.site/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5 "Agrold Wiki on Notion")
+
+[WIKI]: https://img.shields.io/badge/Read_our_Wiki_on_Notion-_?style=for-the-badge&logo=notion&logoColor=white&color=86B817
 
 
 ### Cloner l'appli

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -3,6 +3,8 @@
 - `git clone --branch dev `
 -
 
+Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur le Notion](https://www.notion.so/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5)
+
 ### Deployer l'appli web
 
 #### Pré requis

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -14,26 +14,26 @@
 
 Le déploiement de l'application se fait premièrement avec des propriétés Java passées à tomcat.
 
-|            Name            |                                             Description                                              |       Valeur par défaut       |
-|:--------------------------:|:----------------------------------------------------------------------------------------------------:|:-----------------------------:|
-|       `agrold.name`        | Nom de l'archive et du contexte (the name after the base URL, for instance `https://someurl/agrold`) |            `aldp`             |
-|    `agrold.description`    |                                   Description affichée dans Tomcat                                   |              :x:              |
-|      `agrold.baseurl`      |                                        L'URL de base de l'app                                        |   `http://localhost:8080/`    |
-|  `agrold.sparql_endpoint`  |                                       Url de l'endpoint SPARQL                                       | `http://sparql.southgreen.fr` |
-| `agrold.db_connection_url` |                       Url de la base de données ex: `[host]:[port]/[db]?[opt]`                       |         :x: (requis)          |
-|    `agrold.db_username`    |                                  Utilisateur de la base de données                                   |         :x: (requis)          |
-|    `agrold.db_password`    |                                  Mot de passe de la base de données                                  |         :x: (requis)          |
+|            Name            |                                                                    Description                                                                    |       Valeur par défaut       |
+| :------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------: |
+|       `agrold.name`        | Nom de l'archive et du contexte (le nom apparait après `agrold.baseurl` , par exemple si on met la valeur à `aldp` on a `https://someurl/agrold`) |            `aldp`             |
+|    `agrold.description`    |                                                         Description affichée dans Tomcat                                                          |              :x:              |
+|      `agrold.baseurl`      |                                                              L'URL de base de l'app                                                               |   `http://localhost:8080/`    |
+|  `agrold.sparql_endpoint`  |                                                             Url de l'endpoint SPARQL                                                              | `http://sparql.southgreen.fr` |
+| `agrold.db_connection_url` |                                             Url de la base de données ex: `[host]:[port]/[db]?[opt]`                                              |         :x: (requis)          |
+|    `agrold.db_username`    |                                                         Utilisateur de la base de données                                                         |         :x: (requis)          |
+|    `agrold.db_password`    |                                                        Mot de passe de la base de données                                                         |         :x: (requis)          |
 
+Pour injecter ces variables dans tomcat, il faut déclarer les sous forme d'argument en ligne de commande sous cette forme `-Dnomdelapropriété=valeur` et les placer dans la variable d'environnement `CATALINA_OPTS`
 
-Pour injecter ces variables dans tomcat, il faut déclarer les sous forme d'argument en ligne de commande sous cette forme `-Dnomdelapropriété=valeur` et les placer dans la variable d'environnement `CATALINA_OPTS` 
+> [!IMPORTANT]
+> Non ce n'est pas une faute de frappe le `-D` est bien collé au nom de la propriété, c'est les arguments de java
 
-> :warning: Non ce n'est pas une faute de frappe le `-D` est bien collé au nom de la propriété, c'est les arguments de java
-
-Par exemple: 
+Par exemple:
 
 ```bash
 # Directement sur l'hôte
-export CATALINA_OPTS="-Dagrold.db_connection_url=someurlhere -Dagrold.db_username=usr -Dagrold.db_password=pwd" 
+export CATALINA_OPTS="-Dagrold.db_connection_url=someurlhere -Dagrold.db_username=usr -Dagrold.db_password=pwd"
 catalina.sh
 ```
 
@@ -45,7 +45,6 @@ String pwd = System.getProperty("agrold.db_password");
 ...
 ```
 
-
 Si vous lancez tomcat avec systemd le remplissage des variables d'environnement se fait ainsi
 
 ```bash
@@ -56,19 +55,24 @@ sudo systemctl edit tomcat8 #ou tomcat7
 Environment="CATALINA_OPTS='-Dagrold.db_connection_url=someurlhere -Dagrold.db_username=usr -Dagrold.db_password=pwd'"
 ```
 
-Pour compiler: la variable d'environnement `AGROLD_NAME`, égale à `agrold.name` doit être mise en place 
+Pour compiler lancez maven à la racine du projet, Il est possible de passer la propriété `agrold.name` en argument de maven
 
 ```bash
-# Avec AGROLD_NAME définie précédemment
 mvn clean install
+
+# ou
+
+mvn clean install -Dagrold.name=un_nom # vous accéderez à l'application via https://<votre url>/un_nom
+```
 ```
 
 Si vous utilisez docker:
+
 ```bash
 cd agrold-javaweb/
 
 # Vous pouvez utiliser le dockerfile
-#                          le mot de passe du manager 
+#                          le mot de passe du manager
 docker build . -t <tag> --build-arg TOMCAT_PASSWORD=a --build-arg AGROLD_NAME=agrolddev
 
 # Ou pull l'image stockée depuis le registre dans l'environnement de développement,
@@ -78,6 +82,9 @@ docker pull 10.9.2.21:8080
 # Lancer le conteneur
 docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.baseurl=http://localhost:8080/ -Dagrold.sparql_endpoint=a" <tag>
 ```
+
+> [!NOTE]
+> À noter que l'image docker crée prend pour base l'image [bitnami/tomcat](https://hub.docker.com/r/bitnami/tomcat/). Cela veut dire que vous pouvez configurer l'image d'AgroLD comme celle de bitnami sur certain points nottament la configuration de l'utilisateur manager de tomcat.
 
 ### Sauvegarde des activités
 

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -1,9 +1,12 @@
+![Static Badge](https://img.shields.io/badge/Read_our_Wiki_on_Notion-_?style=for-the-badge&logo=notion&logoColor=white&color=86B817&link=https%3A%2F%2Fagrold-wiki.notion.site%2FWiki-AgroLD-2db695645df945e693b9d8ad3244e7bc)
+
+
 ### Cloner l'appli
 
 - `git clone --branch dev `
 -
 
-Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur le Notion](https://www.notion.so/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5)
+Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur le Notion](https://agrold-wiki.notion.site/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5)
 
 ### Deployer l'appli web
 

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -2,7 +2,6 @@
 
 [WIKI]: https://img.shields.io/badge/Read_our_Wiki_on_Notion-_?style=for-the-badge&logo=notion&logoColor=white&color=86B817
 
-
 ### Cloner l'appli
 
 - `git clone --branch dev `
@@ -30,6 +29,7 @@ Le déploiement de l'application se fait premièrement avec des propriétés Jav
 | `agrold.db_connection_url` |                                             Url de la base de données ex: `[host]:[port]/[db]?[opt]`                                              |         :x: (requis)          |
 |    `agrold.db_username`    |                                                         Utilisateur de la base de données                                                         |         :x: (requis)          |
 |    `agrold.db_password`    |                                                        Mot de passe de la base de données                                                         |         :x: (requis)          |
+|      `agrold.rf_link`      |                                                   Lien vers une instance de RelFinder[Reformed]                                                   |  `http://rf.southgreen.fr/`   |
 
 Pour injecter ces variables dans tomcat, il faut déclarer les sous forme d'argument en ligne de commande sous cette forme `-Dnomdelapropriété=valeur` et les placer dans la variable d'environnement `CATALINA_OPTS`
 
@@ -71,7 +71,8 @@ mvn clean install
 
 mvn clean install -Dagrold.name=un_nom # vous accéderez à l'application via https://<votre url>/un_nom
 ```
-```
+
+````
 
 Si vous utilisez docker:
 
@@ -88,7 +89,7 @@ docker pull 10.9.2.21:8080
 
 # Lancer le conteneur
 docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.baseurl=http://localhost:8080/ -Dagrold.sparql_endpoint=a" <tag>
-```
+````
 
 > [!NOTE]
 > À noter que l'image docker crée prend pour base l'image [bitnami/tomcat](https://hub.docker.com/r/bitnami/tomcat/). Cela veut dire que vous pouvez configurer l'image d'AgroLD comme celle de bitnami sur certain points nottament la configuration de l'utilisateur manager de tomcat.

--- a/agrold-javaweb/charts/agrold-javaweb/.helmignore
+++ b/agrold-javaweb/charts/agrold-javaweb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.lock
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.0.3
+digest: sha256:7d4a98a9fabc3be62a3898cc530d0979b6a0a4d29c87ed2d128821f21c89ba40
+generated: "2022-09-19T14:23:55.173593332Z"

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.lock
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.3
-digest: sha256:7d4a98a9fabc3be62a3898cc530d0979b6a0a4d29c87ed2d128821f21c89ba40
-generated: "2022-09-19T14:23:55.173593332Z"
+  version: 2.14.1
+- name: virtuoso
+  repository: file://../virtuoso
+  version: 0.1.0
+digest: sha256:c582e2a872feb8c8cb2fe1c1587f0e46b2170284be489805c86fe8c42584600f
+generated: "2024-02-09T15:18:42.633332491+01:00"

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
@@ -1,0 +1,30 @@
+annotations:
+  category: ApplicationServer
+apiVersion: v2
+appVersion: 10.0.23
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - bitnami-common
+  version: 2.x.x
+description: Apache Tomcat is an open-source web server designed to host and run Java-based
+  web applications. It is a lightweight server with a good performance for applications
+  running in production environments.
+home: https://github.com/bitnami/charts/tree/master/bitnami/tomcat
+icon: https://bitnami.com/assets/stacks/tomcat/img/tomcat-stack-220x234.png
+keywords:
+- tomcat
+- java
+- http
+- web
+- application server
+- jsp
+maintainers:
+- name: Bitnami
+  url: https://github.com/bitnami/charts
+name: tomcat
+sources:
+- https://github.com/bitnami/containers/tree/main/bitnami/tomcat
+- http://tomcat.apache.org
+version: 10.4.5

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
@@ -3,28 +3,34 @@ annotations:
 apiVersion: v2
 appVersion: 10.0.23
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  tags:
-  - bitnami-common
-  version: 2.x.x
-description: Apache Tomcat is an open-source web server designed to host and run Java-based
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 2.x.x
+description:
+  Apache Tomcat is an open-source web server designed to host and run Java-based
   web applications. It is a lightweight server with a good performance for applications
   running in production environments.
 home: https://github.com/bitnami/charts/tree/master/bitnami/tomcat
 icon: https://bitnami.com/assets/stacks/tomcat/img/tomcat-stack-220x234.png
 keywords:
-- tomcat
-- java
-- http
-- web
-- application server
-- jsp
+  - tomcat
+  - java
+  - http
+  - web
+  - application server
+  - jsp
+  - RDF
+  - SPARQL
+  - Semantic Web
 maintainers:
-- name: Bitnami
-  url: https://github.com/bitnami/charts
-name: tomcat
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
+  - name: Yann POMIE
+    url: https://yann-pomie.fr
+name: agrold-javaweb
 sources:
-- https://github.com/bitnami/containers/tree/main/bitnami/tomcat
-- http://tomcat.apache.org
+  - https://github.com/bitnami/containers/tree/main/bitnami/tomcat
+  - http://tomcat.apache.org
 version: 10.4.5

--- a/agrold-javaweb/charts/agrold-javaweb/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/README.md
@@ -1,0 +1,405 @@
+<!--- app-name: Apache Tomcat -->
+
+# Apache Tomcat packaged by Bitnami
+
+Apache Tomcat is an open-source web server designed to host and run Java-based web applications. It is a lightweight server with a good performance for applications running in production environments.
+
+[Overview of Apache Tomcat](http://tomcat.apache.org/)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+                           
+## TL;DR
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/tomcat
+```
+
+## Introduction
+
+This chart bootstraps a [Tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Tomcat implements several Java EE specifications including Java Servlet, JavaServer Pages, Java EL, and WebSocket, and provides a "pure Java" HTTP web server environment for Java code to run in.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure
+- ReadWriteMany volumes for deployment scaling
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/tomcat
+```
+
+These commands deploy Tomcat on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+
+
+### Common parameters
+
+| Name                | Description                                                                                  | Value           |
+| ------------------- | -------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`            |
+| `nameOverride`      | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname template                                      | `""`            |
+| `commonLabels`      | Add labels to all the deployed resources                                                     | `{}`            |
+| `commonAnnotations` | Add annotations to all the deployed resources                                                | `{}`            |
+| `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
+
+
+### Tomcat parameters
+
+| Name                          | Description                                                                                            | Value                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `image.registry`              | Tomcat image registry                                                                                  | `docker.io`             |
+| `image.repository`            | Tomcat image repository                                                                                | `bitnami/tomcat`        |
+| `image.tag`                   | Tomcat image tag (immutable tags are recommended)                                                      | `10.0.23-debian-11-r19` |
+| `image.digest`                | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `image.pullPolicy`            | Tomcat image pull policy                                                                               | `IfNotPresent`          |
+| `image.pullSecrets`           | Specify docker-registry secret names as an array                                                       | `[]`                    |
+| `image.debug`                 | Specify if debug logs should be enabled                                                                | `false`                 |
+| `hostAliases`                 | Deployment pod host aliases                                                                            | `[]`                    |
+| `tomcatUsername`              | Tomcat admin user                                                                                      | `user`                  |
+| `tomcatPassword`              | Tomcat admin password                                                                                  | `""`                    |
+| `tomcatAllowRemoteManagement` | Enable remote access to management interface                                                           | `0`                     |
+| `catalinaOpts`                | Java runtime option used by tomcat JVM                                                                 | `""`                    |
+| `command`                     | Override default container command (useful when using custom images)                                   | `[]`                    |
+| `args`                        | Override default container args (useful when using custom images)                                      | `[]`                    |
+| `extraEnvVars`                | Extra environment variables to be set on Tomcat container                                              | `[]`                    |
+| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra environment variables                                      | `""`                    |
+| `extraEnvVarsSecret`          | Name of existing Secret containing extra environment variables                                         | `""`                    |
+
+
+### Tomcat deployment parameters
+
+| Name                                       | Description                                                                                                              | Value               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `replicaCount`                             | Specify number of Tomcat replicas                                                                                        | `1`                 |
+| `deployment.type`                          | Use Deployment or StatefulSet                                                                                            | `deployment`        |
+| `updateStrategy.type`                      | StrategyType                                                                                                             | `RollingUpdate`     |
+| `containerPorts.http`                      | HTTP port to expose at container level                                                                                   | `8080`              |
+| `containerExtraPorts`                      | Extra ports to expose at container level                                                                                 | `[]`                |
+| `podSecurityContext.enabled`               | Enable Tomcat pods' Security Context                                                                                     | `true`              |
+| `podSecurityContext.fsGroup`               | Set Tomcat pod's Security Context fsGroup                                                                                | `1001`              |
+| `containerSecurityContext.enabled`         | Enable Tomcat containers' SecurityContext                                                                                | `true`              |
+| `containerSecurityContext.runAsUser`       | User ID for the Tomcat container                                                                                         | `1001`              |
+| `containerSecurityContext.runAsNonRoot`    | Force user to be root in Tomcat container                                                                                | `true`              |
+| `resources.limits`                         | The resources limits for the Tomcat container                                                                            | `{}`                |
+| `resources.requests`                       | The requested resources for the Tomcat container                                                                         | `{}`                |
+| `livenessProbe.enabled`                    | Enable livenessProbe                                                                                                     | `true`              |
+| `livenessProbe.initialDelaySeconds`        | Initial delay seconds for livenessProbe                                                                                  | `120`               |
+| `livenessProbe.periodSeconds`              | Period seconds for livenessProbe                                                                                         | `10`                |
+| `livenessProbe.timeoutSeconds`             | Timeout seconds for livenessProbe                                                                                        | `5`                 |
+| `livenessProbe.failureThreshold`           | Failure threshold for livenessProbe                                                                                      | `6`                 |
+| `livenessProbe.successThreshold`           | Success threshold for livenessProbe                                                                                      | `1`                 |
+| `readinessProbe.enabled`                   | Enable readinessProbe                                                                                                    | `true`              |
+| `readinessProbe.initialDelaySeconds`       | Initial delay seconds for readinessProbe                                                                                 | `30`                |
+| `readinessProbe.periodSeconds`             | Period seconds for readinessProbe                                                                                        | `5`                 |
+| `readinessProbe.timeoutSeconds`            | Timeout seconds for readinessProbe                                                                                       | `3`                 |
+| `readinessProbe.failureThreshold`          | Failure threshold for readinessProbe                                                                                     | `3`                 |
+| `readinessProbe.successThreshold`          | Success threshold for readinessProbe                                                                                     | `1`                 |
+| `startupProbe.enabled`                     | Enable startupProbe                                                                                                      | `false`             |
+| `startupProbe.initialDelaySeconds`         | Initial delay seconds for startupProbe                                                                                   | `30`                |
+| `startupProbe.periodSeconds`               | Period seconds for startupProbe                                                                                          | `5`                 |
+| `startupProbe.timeoutSeconds`              | Timeout seconds for startupProbe                                                                                         | `3`                 |
+| `startupProbe.failureThreshold`            | Failure threshold for startupProbe                                                                                       | `3`                 |
+| `startupProbe.successThreshold`            | Success threshold for startupProbe                                                                                       | `1`                 |
+| `customLivenessProbe`                      | Override default liveness probe                                                                                          | `{}`                |
+| `customReadinessProbe`                     | Override default readiness probe                                                                                         | `{}`                |
+| `customStartupProbe`                       | Override default startup probe                                                                                           | `{}`                |
+| `podLabels`                                | Extra labels for Tomcat pods                                                                                             | `{}`                |
+| `podAnnotations`                           | Annotations for Tomcat pods                                                                                              | `{}`                |
+| `podAffinityPreset`                        | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                |
+| `podAntiAffinityPreset`                    | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`              |
+| `nodeAffinityPreset.type`                  | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                |
+| `nodeAffinityPreset.key`                   | Node label key to match. Ignored if `affinity` is set.                                                                   | `""`                |
+| `nodeAffinityPreset.values`                | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                |
+| `affinity`                                 | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                |
+| `nodeSelector`                             | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                |
+| `schedulerName`                            | Alternative scheduler                                                                                                    | `""`                |
+| `lifecycleHooks`                           | Override default etcd container hooks                                                                                    | `{}`                |
+| `podManagementPolicy`                      | podManagementPolicy to manage scaling operation of pods (only in StatefulSet mode)                                       | `""`                |
+| `tolerations`                              | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                |
+| `topologySpreadConstraints`                | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                |
+| `extraPodSpec`                             | Optionally specify extra PodSpec                                                                                         | `{}`                |
+| `extraVolumes`                             | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                                        | `[]`                |
+| `extraVolumeClaimTemplates`                | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet                        | `[]`                |
+| `extraVolumeMounts`                        | Optionally specify extra list of additional volumeMounts for Tomcat container(s)                                         | `[]`                |
+| `initContainers`                           | Add init containers to the Tomcat pods.                                                                                  | `[]`                |
+| `sidecars`                                 | Add sidecars to the Tomcat pods.                                                                                         | `[]`                |
+| `persistence.enabled`                      | Enable persistence                                                                                                       | `true`              |
+| `persistence.storageClass`                 | PVC Storage Class for Tomcat volume                                                                                      | `""`                |
+| `persistence.annotations`                  | Persistent Volume Claim annotations                                                                                      | `{}`                |
+| `persistence.accessModes`                  | PVC Access Modes for Tomcat volume                                                                                       | `["ReadWriteOnce"]` |
+| `persistence.size`                         | PVC Storage Request for Tomcat volume                                                                                    | `8Gi`               |
+| `persistence.existingClaim`                | An Existing PVC name for Tomcat volume                                                                                   | `""`                |
+| `persistence.selectorLabels`               | Selector labels to use in volume claim template in statefulset                                                           | `{}`                |
+| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.                                    | `false`             |
+| `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
+| `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
+
+
+### Traffic Exposure parameters
+
+| Name                               | Description                                                                                                                      | Value                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Kubernetes Service type                                                                                                          | `LoadBalancer`           |
+| `service.ports.http`               | Service HTTP port                                                                                                                | `80`                     |
+| `service.nodePorts.http`           | Kubernetes http node port                                                                                                        | `""`                     |
+| `service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                                                                   | `[]`                     |
+| `service.loadBalancerIP`           | Port Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank                                            | `""`                     |
+| `service.clusterIP`                | Service Cluster IP                                                                                                               | `""`                     |
+| `service.loadBalancerSourceRanges` | Service Load Balancer sources                                                                                                    | `[]`                     |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                                             | `Cluster`                |
+| `service.annotations`              | Annotations for Tomcat service                                                                                                   | `{}`                     |
+| `service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                             | `None`                   |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `ingress.enabled`                  | Enable ingress controller resource                                                                                               | `false`                  |
+| `ingress.hostname`                 | Default host for the ingress resource                                                                                            | `tomcat.local`           |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter                                                | `false`                  |
+| `ingress.extraHosts`               | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
+| `ingress.extraTls`                 | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
+| `ingress.extraPaths`               | Any additional arbitrary paths that may need to be added to the ingress under the main host.                                     | `[]`                     |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
+| `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.path`                     | Ingress path                                                                                                                     | `/`                      |
+| `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
+
+
+### Volume Permissions parameters
+
+| Name                                   | Description                                                                                                                       | Value                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory                                                       | `false`                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                       | `11-debian-11-r36`      |
+| `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                                | `{}`                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                              | `{}`                    |
+
+
+### Metrics parameters
+
+| Name                                                | Description                                                                                                  | Value                                                                                                                                                                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metrics.jmx.enabled`                               | Whether or not to expose JMX metrics to Prometheus                                                           | `false`                                                                                                                                                                                                             |
+| `metrics.jmx.catalinaOpts`                          | custom option used to enabled JMX on tomcat jvm evaluated as template                                        | `-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true` |
+| `metrics.jmx.image.registry`                        | JMX exporter image registry                                                                                  | `docker.io`                                                                                                                                                                                                         |
+| `metrics.jmx.image.repository`                      | JMX exporter image repository                                                                                | `bitnami/jmx-exporter`                                                                                                                                                                                              |
+| `metrics.jmx.image.tag`                             | JMX exporter image tag (immutable tags are recommended)                                                      | `0.17.1-debian-11-r2`                                                                                                                                                                                               |
+| `metrics.jmx.image.digest`                          | JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                                                                                                                                                                                                |
+| `metrics.jmx.image.pullPolicy`                      | JMX exporter image pull policy                                                                               | `IfNotPresent`                                                                                                                                                                                                      |
+| `metrics.jmx.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                             | `[]`                                                                                                                                                                                                                |
+| `metrics.jmx.config`                                | Configuration file for JMX exporter                                                                          | `""`                                                                                                                                                                                                                |
+| `metrics.jmx.containerSecurityContext.enabled`      | Enable Prometheus JMX exporter containers' Security Context                                                  | `true`                                                                                                                                                                                                              |
+| `metrics.jmx.containerSecurityContext.runAsUser`    | Set Prometheus JMX exporter containers' Security Context runAsUser                                           | `1001`                                                                                                                                                                                                              |
+| `metrics.jmx.containerSecurityContext.runAsNonRoot` | Set Prometheus JMX exporter containers' Security Context runAsNonRoot                                        | `true`                                                                                                                                                                                                              |
+| `metrics.jmx.resources.limits`                      | JMX Exporter container resource limits                                                                       | `{}`                                                                                                                                                                                                                |
+| `metrics.jmx.resources.requests`                    | JMX Exporter container resource requests                                                                     | `{}`                                                                                                                                                                                                                |
+| `metrics.jmx.ports.metrics`                         | JMX Exporter container metrics ports                                                                         | `5556`                                                                                                                                                                                                              |
+| `metrics.jmx.existingConfigmap`                     | Name of existing ConfigMap with JMX exporter configuration                                                   | `""`                                                                                                                                                                                                                |
+| `metrics.podMonitor.podTargetLabels`                | Used to keep given pod's labels in target                                                                    | `[]`                                                                                                                                                                                                                |
+| `metrics.podMonitor.enabled`                        | Create PodMonitor Resource for scraping metrics using PrometheusOperator                                     | `false`                                                                                                                                                                                                             |
+| `metrics.podMonitor.namespace`                      | Optional namespace in which Prometheus is running                                                            | `""`                                                                                                                                                                                                                |
+| `metrics.podMonitor.interval`                       | Specify the interval at which metrics should be scraped                                                      | `30s`                                                                                                                                                                                                               |
+| `metrics.podMonitor.scrapeTimeout`                  | Specify the timeout after which the scrape is ended                                                          | `30s`                                                                                                                                                                                                               |
+| `metrics.podMonitor.additionalLabels`               | Additional labels that can be used so PodMonitors will be discovered by Prometheus                           | `{}`                                                                                                                                                                                                                |
+| `metrics.podMonitor.scheme`                         | Scheme to use for scraping                                                                                   | `http`                                                                                                                                                                                                              |
+| `metrics.podMonitor.tlsConfig`                      | TLS configuration used for scrape endpoints used by Prometheus                                               | `{}`                                                                                                                                                                                                                |
+| `metrics.podMonitor.relabelings`                    | Prometheus relabeling rules                                                                                  | `[]`                                                                                                                                                                                                                |
+| `metrics.prometheusRule.enabled`                    | Set this to true to create prometheusRules for Prometheus operator                                           | `false`                                                                                                                                                                                                             |
+| `metrics.prometheusRule.additionalLabels`           | Additional labels that can be used so prometheusRules will be discovered by Prometheus                       | `{}`                                                                                                                                                                                                                |
+| `metrics.prometheusRule.namespace`                  | namespace where prometheusRules resource should be created                                                   | `""`                                                                                                                                                                                                                |
+| `metrics.prometheusRule.rules`                      | Create specified [Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)         | `[]`                                                                                                                                                                                                                |
+
+
+The above parameters map to the env variables defined in [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat). For more information please refer to the [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install my-release \
+  --set tomcatUsername=manager,tomcatPassword=password bitnami/tomcat
+```
+
+The above command sets the Tomcat management username and password to `manager` and `password` respectively.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install my-release -f values.yaml bitnami/tomcat
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling vs Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Use a different Tomcat version
+
+To modify the application version used in this chart, specify a different version of the image using the `image.tag` parameter and/or a different repository using the `image.repository` parameter. Refer to the [chart documentation for more information on these parameters and how to use them with images from a private registry](https://docs.bitnami.com/kubernetes/infrastructure/tomcat/configuration/change-image-version/).
+
+### Add extra environment variables
+
+To add extra environment variables (useful for advanced operations like custom init scripts), use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: DEBUG
+```
+
+Alternatively, define a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Use Sidecars and Init Containers
+
+If additional containers are needed in the same pod (such as additional metrics or logging exporters), they can be defined using the `sidecars` config parameter. Similarly, extra init containers can be added using the `initContainers` parameter.
+
+Refer to the chart documentation for more information on, and examples of, configuring and using [sidecars and init containers](https://docs.bitnami.com/kubernetes/infrastructure/tomcat/configuration/configure-sidecar-init-containers/).
+
+### Set Pod affinity
+
+This chart allows you to set custom Pod affinity using the `affinity` parameter. Find more information about Pod's affinity in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+## Persistence
+
+The [Bitnami Tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) image stores the Tomcat data and configurations at the `/bitnami/tomcat` path of the container.
+
+Persistent Volume Claims (PVCs) are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+
+See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+
+### Adjust permissions of persistent volume mountpoint
+
+As the image run as non-root by default, it is necessary to adjust the ownership of the persistent volume so that the container can write data into it.
+
+By default, the chart is configured to use Kubernetes Security Context to automatically change the ownership of the volume. However, this feature does not work in all Kubernetes distributions.
+As an alternative, this chart supports using an init container to change the ownership of the volume before mounting it in the final destination.
+
+You can enable this init container by setting `volumePermissions.enabled` to `true`.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 10.0.0
+
+Some of the chart values were changed to adapt to the latest Bitnami standards. More specifically:
+
+- `containerPort` was changed to `containerPorts.http`
+- `service.port` was changed to `service.ports.http`
+
+No issues should be expected when upgrading.
+
+### To 8.0.0
+
+- Chart labels were adapted to follow the [Helm charts standard labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
+- Ingress configuration was also adapted to follow the Helm charts best practices.
+- This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+Consequences:
+
+- Backwards compatibility is not guaranteed. However, you can easily workaround this issue by removing Tomcat deployment before upgrading (the following example assumes that the release name is `tomcat`):
+
+```console
+$ export TOMCAT_PASSWORD=$(kubectl get secret --namespace default tomcat -o jsonpath="{.data.tomcat-password}" | base64 -d)
+$ kubectl delete deployments.apps tomcat
+$ helm upgrade tomcat bitnami/tomcat --set tomcatPassword=$TOMCAT_PASSWORD
+```
+
+### To 7.0.0
+
+[On November 13, 2020, Helm v2 support formally ended](https://github.com/helm/charts#status-of-the-project). This major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+[Learn more about this change and related upgrade considerations](https://docs.bitnami.com/kubernetes/infrastructure/tomcat/administration/upgrade-helm3/).
+
+### To 5.0.0
+
+This release updates the Bitnami Tomcat container to `9.0.26-debian-9-r0`, which is based on Bash instead of Node.js.
+
+### To 2.1.0
+
+Tomcat container was moved to a non-root approach. There shouldn't be any issue when upgrading since the corresponding `securityContext` is enabled by default. Both the container image and the chart can be upgraded by running the command below:
+
+```
+$ helm upgrade my-release bitnami/tomcat
+```
+
+If you use a previous container image (previous to **8.5.35-r26**) disable the `securityContext` by running the command below:
+
+```
+$ helm upgrade my-release bitnami/tomcat --set securityContext.enabled=false,image.tag=XXX
+```
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is tomcat:
+
+```console
+$ kubectl patch deployment tomcat --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/agrold-javaweb/charts/agrold-javaweb/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/README.md
@@ -7,7 +7,7 @@ Apache Tomcat is an open-source web server designed to host and run Java-based w
 [Overview of Apache Tomcat](http://tomcat.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -55,6 +55,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
+### Agrold parameters
+
+| Name                                 | Description                                  | Value       |
+| ------------------------------------ | -------------------------------------------- | ----------- |
+| `agroldProperties.db_connection_url` | Database connection URL for user management. | `"someurl"` |
+| `agroldProperties.db_username`       | Database username for user management.       | `"user"`    |
+| `agroldProperties.db_password`       | Database password for user management.       | `"user"`    |
+
+> ℹ️ You can also add other parameters as [mentionned in the readme](https://github.com/SouthGreenPlatform/AgroLD_webapp/tree/master/agrold-javaweb#param%C3%A8tres)
+
 ### Global parameters
 
 | Name                      | Description                                     | Value |
@@ -62,7 +72,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
-
 
 ### Common parameters
 
@@ -75,7 +84,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `commonAnnotations` | Add annotations to all the deployed resources                                                | `{}`            |
 | `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
-
 
 ### Tomcat parameters
 
@@ -98,7 +106,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVars`                | Extra environment variables to be set on Tomcat container                                              | `[]`                    |
 | `extraEnvVarsCM`              | Name of existing ConfigMap containing extra environment variables                                      | `""`                    |
 | `extraEnvVarsSecret`          | Name of existing Secret containing extra environment variables                                         | `""`                    |
-
 
 ### Tomcat deployment parameters
 
@@ -168,7 +175,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
 | `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
 
-
 ### Traffic Exposure parameters
 
 | Name                               | Description                                                                                                                      | Value                    |
@@ -199,7 +205,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.path`                     | Ingress path                                                                                                                     | `/`                      |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 
-
 ### Volume Permissions parameters
 
 | Name                                   | Description                                                                                                                       | Value                   |
@@ -211,9 +216,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
-| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                                | `{}`                    |
-| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                              | `{}`                    |
-
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource limits                                                                                 | `{}`                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource requests                                                                               | `{}`                    |
 
 ### Metrics parameters
 
@@ -248,7 +252,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.additionalLabels`           | Additional labels that can be used so prometheusRules will be discovered by Prometheus                       | `{}`                                                                                                                                                                                                                |
 | `metrics.prometheusRule.namespace`                  | namespace where prometheusRules resource should be created                                                   | `""`                                                                                                                                                                                                                |
 | `metrics.prometheusRule.rules`                      | Create specified [Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)         | `[]`                                                                                                                                                                                                                |
-
 
 The above parameters map to the env variables defined in [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat). For more information please refer to the [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) image documentation.
 

--- a/agrold-javaweb/charts/agrold-javaweb/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/README.md
@@ -57,11 +57,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Agrold parameters
 
-| Name                                 | Description                                  | Value       |
-| ------------------------------------ | -------------------------------------------- | ----------- |
-| `agroldProperties.db_connection_url` | Database connection URL for user management. | `"someurl"` |
-| `agroldProperties.db_username`       | Database username for user management.       | `"user"`    |
-| `agroldProperties.db_password`       | Database password for user management.       | `"user"`    |
+| Name                                 | Description                                  | Value                     |
+| ------------------------------------ | -------------------------------------------- | ------------------------- |
+| `agroldProperties.db_connection_url` | Database connection URL for user management. | `"someurl"`               |
+| `agroldProperties.db_username`       | Database username for user management.       | `"user"`                  |
+| `agroldProperties.db_password`       | Database password for user management.       | `"password"`              |
+| `agroldProperties.rf_link`           | Link to RelFinder **ingress**.               | `"https://rf.someurl.fr"` |
+| `agroldProperties.description`       | Description showed in Tomcat.                | `""`                      |
 
 > ℹ️ You can also add other parameters as [mentionned in the readme](https://github.com/SouthGreenPlatform/AgroLD_webapp/tree/master/agrold-javaweb#param%C3%A8tres)
 

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/.helmignore
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/Chart.yaml
@@ -1,0 +1,23 @@
+annotations:
+  category: Infrastructure
+apiVersion: v2
+appVersion: 2.0.3
+description: A Library Helm Chart for grouping common logic between bitnami charts.
+  This chart is not deployable by itself.
+home: https://github.com/bitnami/charts/tree/master/bitnami/common
+icon: https://bitnami.com/downloads/logos/bitnami-mark.png
+keywords:
+- common
+- helper
+- template
+- function
+- bitnami
+maintainers:
+- name: Bitnami
+  url: https://github.com/bitnami/charts
+name: common
+sources:
+- https://github.com/bitnami/charts
+- https://www.bitnami.com/
+type: library
+version: 2.0.3

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/README.md
@@ -1,0 +1,350 @@
+# Bitnami Common Library Chart
+
+A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for grouping common logic between bitnami charts.
+
+## TL;DR
+
+```yaml
+dependencies:
+  - name: common
+    version: 1.x.x
+    repository: https://charts.bitnami.com/bitnami
+```
+
+```bash
+$ helm dependency update
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+data:
+  myvalue: "Hello World"
+```
+
+## Introduction
+
+This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Parameters
+
+The following table lists the helpers available in the library which are scoped in different sections.
+
+### Affinities
+
+| Helper identifier             | Description                                          | Expected Input                                 |
+|-------------------------------|------------------------------------------------------|------------------------------------------------|
+| `common.affinities.nodes.soft` | Return a soft nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
+| `common.affinities.nodes.hard` | Return a hard nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
+| `common.affinities.pods.soft`  | Return a soft podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
+| `common.affinities.pods.hard`  | Return a hard podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
+
+### Capabilities
+
+| Helper identifier                              | Description                                                                                    | Expected Input    |
+|------------------------------------------------|------------------------------------------------------------------------------------------------|-------------------|
+| `common.capabilities.kubeVersion`              | Return the target Kubernetes version (using client default if .Values.kubeVersion is not set). | `.` Chart context |
+| `common.capabilities.cronjob.apiVersion`       | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context |
+| `common.capabilities.deployment.apiVersion`    | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
+| `common.capabilities.statefulset.apiVersion`   | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
+| `common.capabilities.ingress.apiVersion`       | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
+| `common.capabilities.rbac.apiVersion`          | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context |
+| `common.capabilities.crd.apiVersion`           | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
+| `common.capabilities.policy.apiVersion`        | Return the appropriate apiVersion for podsecuritypolicy.                                       | `.` Chart context |
+| `common.capabilities.networkPolicy.apiVersion` | Return the appropriate apiVersion for networkpolicy.                                           | `.` Chart context |
+| `common.capabilities.apiService.apiVersion`    | Return the appropriate apiVersion for APIService.                                              | `.` Chart context |
+| `common.capabilities.hpa.apiVersion`           | Return the appropriate apiVersion for Horizontal Pod Autoscaler                                | `.` Chart context |
+| `common.capabilities.supportsHelmVersion`      | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
+
+### Errors
+
+| Helper identifier                       | Description                                                                                                                                                            | Expected Input                                                                      |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `common.errors.upgrade.passwords.empty` | It will ensure required passwords are given when we are upgrading a chart. If `validationErrors` is not empty it will throw an error and will stop the upgrade action. | `dict "validationErrors" (list $validationError00 $validationError01)  "context" $` |
+
+### Images
+
+| Helper identifier           | Description                                          | Expected Input                                                                                          |
+|-----------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `common.images.image`       | Return the proper and full image name                | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageroot) for the structure. |
+| `common.images.pullSecrets` | Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead) | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global` |
+| `common.images.renderPullSecrets` | Return the proper Docker Image Registry Secret Names (evaluates values as templates) | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $` |
+
+### Ingress
+
+| Helper identifier                         | Description                                                                                                       | Expected Input                                                                                                                                                                   |
+|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version                                              | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
+| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                                                                  | `.` Chart context                                                                                                                                                                |
+| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported                                                          | `.` Chart context                                                                                                                                                                |
+| `common.ingress.certManagerRequest`       | Prints "true" if required cert-manager annotations for TLS signed certificates are set in the Ingress annotations | `dict "annotations" .Values.path.to.the.ingress.annotations`                                                                                                                     |
+
+### Labels
+
+| Helper identifier           | Description                                                                 | Expected Input    |
+|-----------------------------|-----------------------------------------------------------------------------|-------------------|
+| `common.labels.standard`    | Return Kubernetes standard labels                                           | `.` Chart context |
+| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector` | `.` Chart context |
+
+### Names
+
+| Helper identifier                 | Description                                                           | Expected Input    |
+|-----------------------------------|-----------------------------------------------------------------------|-------------------|
+| `common.names.name`               | Expand the name of the chart or use `.Values.nameOverride`            | `.` Chart context |
+| `common.names.fullname`           | Create a default fully qualified app name.                            | `.` Chart context |
+| `common.names.namespace`          | Allow the release namespace to be overridden                          | `.` Chart context |
+| `common.names.fullname.namespace` | Create a fully qualified app name adding the installation's namespace | `.` Chart context |
+| `common.names.chart`              | Chart name plus version                                               | `.` Chart context |
+
+### Secrets
+
+| Helper identifier         | Description                                                  | Expected Input                                                                                                                                                                                                                  |
+|---------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.secrets.name`     | Generate the name of the secret.                             | `dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $` see [ExistingSecret](#existingsecret) for the structure.                                                                  |
+| `common.secrets.key`      | Generate secret key.                                         | `dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName"` see [ExistingSecret](#existingsecret) for the structure.                                                                                             |
+| `common.passwords.manage` | Generate secret password or retrieve one if already created. | `dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "context" $`, length, strong and chartNAme fields are optional. |
+| `common.secrets.exists`   | Returns whether a previous generated secret already exists.  | `dict "secret" "secret-name" "context" $`                                                                                                                                                                                       |
+
+### Storage
+
+| Helper identifier             | Description                           | Expected Input                                                                                                      |
+|-------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `common.storage.class` | Return  the proper Storage Class | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure. |
+
+### TplValues
+
+| Helper identifier         | Description                            | Expected Input                                                                                                                                           |
+|---------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.tplvalues.render` | Renders a value that contains template | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frequently is the chart context `$` or `.` |
+
+### Utils
+
+| Helper identifier              | Description                                                                              | Expected Input                                                         |
+|--------------------------------|------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| `common.utils.fieldToEnvVar`   | Build environment variable name given a field.                                           | `dict "field" "my-password"`                                           |
+| `common.utils.secret.getvalue` | Print instructions to get a secret value.                                                | `dict "secret" "secret-name" "field" "secret-value-field" "context" $` |
+| `common.utils.getValueFromKey` | Gets a value from `.Values` object given its key path                                    | `dict "key" "path.to.key" "context" $`                                 |
+| `common.utils.getKeyFromList`  | Returns first `.Values` key with a defined value or first of the list if all non-defined | `dict "keys" (list "path.to.key1" "path.to.key2") "context" $`         |
+
+### Validations
+
+| Helper identifier                                | Description                                                                                                                   | Expected Input                                                                                                                                                                                                                                                           |
+|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.validations.values.single.empty`         | Validate a value must not be empty.                                                                                           | `dict "valueKey" "path.to.value" "secret" "secret.name" "field" "my-password" "subchart" "subchart" "context" $` secret, field and subchart are optional. In case they are given, the helper will generate a how to get instruction. See [ValidateValue](#validatevalue) |
+| `common.validations.values.multiple.empty`       | Validate a multiple values must not be empty. It returns a shared error for all the values.                                   | `dict "required" (list $validateValueConf00 $validateValueConf01) "context" $`. See [ValidateValue](#validatevalue)                                                                                                                                                      |
+| `common.validations.values.mariadb.passwords`    | This helper will ensure required password for MariaDB are not empty. It returns a shared error for all the values.            | `dict "secret" "mariadb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mariadb chart and the helper.                                                                                      |
+| `common.validations.values.mysql.passwords`      | This helper will ensure required password for MySQL are not empty. It returns a shared error for all the values.              | `dict "secret" "mysql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mysql chart and the helper.                                                                                      |
+| `common.validations.values.postgresql.passwords` | This helper will ensure required password for PostgreSQL are not empty. It returns a shared error for all the values.         | `dict "secret" "postgresql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use postgresql chart and the helper.                                                                                |
+| `common.validations.values.redis.passwords`      | This helper will ensure required password for Redis&reg; are not empty. It returns a shared error for all the values. | `dict "secret" "redis-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use redis chart and the helper.                                                                                          |
+| `common.validations.values.cassandra.passwords`  | This helper will ensure required password for Cassandra are not empty. It returns a shared error for all the values.          | `dict "secret" "cassandra-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use cassandra chart and the helper.                                                                                  |
+| `common.validations.values.mongodb.passwords`    | This helper will ensure required password for MongoDB&reg; are not empty. It returns a shared error for all the values.            | `dict "secret" "mongodb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mongodb chart and the helper.                                                                                      |
+
+### Warnings
+
+| Helper identifier            | Description                      | Expected Input                                             |
+|------------------------------|----------------------------------|------------------------------------------------------------|
+| `common.warnings.rollingTag` | Warning about using rolling tag. | `ImageRoot` see [ImageRoot](#imageroot) for the structure. |
+
+## Special input schemas
+
+### ImageRoot
+
+```yaml
+registry:
+  type: string
+  description: Docker registry where the image is located
+  example: docker.io
+
+repository:
+  type: string
+  description: Repository and image name
+  example: bitnami/nginx
+
+tag:
+  type: string
+  description: image tag
+  example: 1.16.1-debian-10-r63
+
+pullPolicy:
+  type: string
+  description: Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+
+pullSecrets:
+  type: array
+  items:
+    type: string
+  description: Optionally specify an array of imagePullSecrets (evaluated as templates).
+
+debug:
+  type: boolean
+  description: Set to true if you would like to see extra information on logs
+  example: false
+
+## An instance would be:
+# registry: docker.io
+# repository: bitnami/nginx
+# tag: 1.16.1-debian-10-r63
+# pullPolicy: IfNotPresent
+# debug: false
+```
+
+### Persistence
+
+```yaml
+enabled:
+  type: boolean
+  description: Whether enable persistence.
+  example: true
+
+storageClass:
+  type: string
+  description: Ghost data Persistent Volume Storage Class, If set to "-", storageClassName: "" which disables dynamic provisioning.
+  example: "-"
+
+accessMode:
+  type: string
+  description: Access mode for the Persistent Volume Storage.
+  example: ReadWriteOnce
+
+size:
+  type: string
+  description: Size the Persistent Volume Storage.
+  example: 8Gi
+
+path:
+  type: string
+  description: Path to be persisted.
+  example: /bitnami
+
+## An instance would be:
+# enabled: true
+# storageClass: "-"
+# accessMode: ReadWriteOnce
+# size: 8Gi
+# path: /bitnami
+```
+
+### ExistingSecret
+
+```yaml
+name:
+  type: string
+  description: Name of the existing secret.
+  example: mySecret
+keyMapping:
+  description: Mapping between the expected key name and the name of the key in the existing secret.
+  type: object
+
+## An instance would be:
+# name: mySecret
+# keyMapping:
+#   password: myPasswordKey
+```
+
+#### Example of use
+
+When we store sensitive data for a deployment in a secret, some times we want to give to users the possibility of using theirs existing secrets.
+
+```yaml
+# templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels:
+    app: {{ include "common.names.fullname" . }}
+type: Opaque
+data:
+  password: {{ .Values.password | b64enc | quote }}
+
+# templates/dpl.yaml
+---
+...
+      env:
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
+              key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "password") }}
+...
+
+# values.yaml
+---
+name: mySecret
+keyMapping:
+  password: myPasswordKey
+```
+
+### ValidateValue
+
+#### NOTES.txt
+
+```console
+{{- $validateValueConf00 := (dict "valueKey" "path.to.value00" "secret" "secretName" "field" "password-00") -}}
+{{- $validateValueConf01 := (dict "valueKey" "path.to.value01" "secret" "secretName" "field" "password-01") -}}
+
+{{ include "common.validations.values.multiple.empty" (dict "required" (list $validateValueConf00 $validateValueConf01) "context" $) }}
+```
+
+If we force those values to be empty we will see some alerts
+
+```console
+$ helm install test mychart --set path.to.value00="",path.to.value01=""
+    'path.to.value00' must not be empty, please add '--set path.to.value00=$PASSWORD_00' to the command. To get the current value:
+
+        export PASSWORD_00=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-00}" | base64 -d)
+
+    'path.to.value01' must not be empty, please add '--set path.to.value01=$PASSWORD_01' to the command. To get the current value:
+
+        export PASSWORD_01=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-01}" | base64 -d)
+```
+
+## Upgrading
+
+### To 1.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Use `type: library`. [Here](https://v3.helm.sh/docs/faq/#library-chart-support) you can find more information.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_affinities.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_affinities.tpl
@@ -1,0 +1,102 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return a soft nodeAffinity definition
+{{ include "common.affinities.nodes.soft" (dict "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes.soft" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - preference:
+      matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . | quote }}
+            {{- end }}
+    weight: 1
+{{- end -}}
+
+{{/*
+Return a hard nodeAffinity definition
+{{ include "common.affinities.nodes.hard" (dict "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes.hard" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  nodeSelectorTerms:
+    - matchExpressions:
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . | quote }}
+            {{- end }}
+{{- end -}}
+
+{{/*
+Return a nodeAffinity definition
+{{ include "common.affinities.nodes" (dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.nodes" -}}
+  {{- if eq .type "soft" }}
+    {{- include "common.affinities.nodes.soft" . -}}
+  {{- else if eq .type "hard" }}
+    {{- include "common.affinities.nodes.hard" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return a soft podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods.soft" (dict "component" "FOO" "extraMatchLabels" .Values.extraMatchLabels "context" $) -}}
+*/}}
+{{- define "common.affinities.pods.soft" -}}
+{{- $component := default "" .component -}}
+{{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - podAffinityTerm:
+      labelSelector:
+        matchLabels: {{- (include "common.labels.matchLabels" .context) | nindent 10 }}
+          {{- if not (empty $component) }}
+          {{ printf "app.kubernetes.io/component: %s" $component }}
+          {{- end }}
+          {{- range $key, $value := $extraMatchLabels }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      namespaces:
+        - {{ include "common.names.namespace" .context | quote }}
+      topologyKey: kubernetes.io/hostname
+    weight: 1
+{{- end -}}
+
+{{/*
+Return a hard podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods.hard" (dict "component" "FOO" "extraMatchLabels" .Values.extraMatchLabels "context" $) -}}
+*/}}
+{{- define "common.affinities.pods.hard" -}}
+{{- $component := default "" .component -}}
+{{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels: {{- (include "common.labels.matchLabels" .context) | nindent 8 }}
+        {{- if not (empty $component) }}
+        {{ printf "app.kubernetes.io/component: %s" $component }}
+        {{- end }}
+        {{- range $key, $value := $extraMatchLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    namespaces:
+      - {{ include "common.names.namespace" .context | quote }}
+    topologyKey: kubernetes.io/hostname
+{{- end -}}
+
+{{/*
+Return a podAffinity/podAntiAffinity definition
+{{ include "common.affinities.pods" (dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")) -}}
+*/}}
+{{- define "common.affinities.pods" -}}
+  {{- if eq .type "soft" }}
+    {{- include "common.affinities.pods.soft" . -}}
+  {{- else if eq .type "hard" }}
+    {{- include "common.affinities.pods.hard" . -}}
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_capabilities.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_capabilities.tpl
@@ -1,0 +1,154 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "common.capabilities.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "common.capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "common.capabilities.networkPolicy.apiVersion" -}}
+{{- if semverCompare "<1.7-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for cronjob.
+*/}}
+{{- define "common.capabilities.cronjob.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "common.capabilities.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apps/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "common.capabilities.ingress.apiVersion" -}}
+{{- if .Values.ingress -}}
+{{- if .Values.ingress.apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- else if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for RBAC resources.
+*/}}
+{{- define "common.capabilities.rbac.apiVersion" -}}
+{{- if semverCompare "<1.17-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRDs.
+*/}}
+{{- define "common.capabilities.crd.apiVersion" -}}
+{{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiextensions.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for APIService.
+*/}}
+{{- define "common.capabilities.apiService.apiVersion" -}}
+{{- if semverCompare "<1.10-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiregistration.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiregistration.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Horizontal Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.hpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if the used Helm version is 3.3+.
+A way to check the used Helm version was not introduced until version 3.3.0 with .Capabilities.HelmVersion, which contains an additional "{}}"  structure.
+This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVersion }} because checking for the key HelmVersion in <3.3 results in a "interface not found" error.
+**To be removed when the catalog's minimun Helm version is 3.3**
+*/}}
+{{- define "common.capabilities.supportsHelmVersion" -}}
+{{- if regexMatch "{(v[0-9])*[^}]*}}$" (.Capabilities | toString ) }}
+  {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_errors.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_errors.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Through error when upgrading using empty passwords values that must not be empty.
+
+Usage:
+{{- $validationError00 := include "common.validations.values.single.empty" (dict "valueKey" "path.to.password00" "secret" "secretName" "field" "password-00") -}}
+{{- $validationError01 := include "common.validations.values.single.empty" (dict "valueKey" "path.to.password01" "secret" "secretName" "field" "password-01") -}}
+{{ include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $validationError00 $validationError01) "context" $) }}
+
+Required password params:
+  - validationErrors - String - Required. List of validation strings to be return, if it is empty it won't throw error.
+  - context - Context - Required. Parent context.
+*/}}
+{{- define "common.errors.upgrade.passwords.empty" -}}
+  {{- $validationErrors := join "" .validationErrors -}}
+  {{- if and $validationErrors .context.Release.IsUpgrade -}}
+    {{- $errorString := "\nPASSWORDS ERROR: You must provide your current passwords when upgrading the release." -}}
+    {{- $errorString = print $errorString "\n                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims." -}}
+    {{- $errorString = print $errorString "\n                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases" -}}
+    {{- $errorString = print $errorString "\n%s" -}}
+    {{- printf $errorString $validationErrors | fail -}}
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_images.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_images.tpl
@@ -1,0 +1,76 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the proper image name
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead)
+{{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global) }}
+*/}}
+{{- define "common.images.pullSecrets" -}}
+  {{- $pullSecrets := list }}
+
+  {{- if .global }}
+    {{- range .global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets . -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ include "common.images.renderPullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $) }}
+*/}}
+{{- define "common.images.renderPullSecrets" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range .images -}}
+    {{- range .pullSecrets -}}
+      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_ingress.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_ingress.tpl
@@ -1,0 +1,68 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Generate backend entry that is compatible with all Kubernetes API versions.
+
+Usage:
+{{ include "common.ingress.backend" (dict "serviceName" "backendName" "servicePort" "backendPort" "context" $) }}
+
+Params:
+  - serviceName - String. Name of an existing service backend
+  - servicePort - String/Int. Port name (or number) of the service. It will be translated to different yaml depending if it is a string or an integer.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "common.ingress.backend" -}}
+{{- $apiVersion := (include "common.capabilities.ingress.apiVersion" .context) -}}
+{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
+serviceName: {{ .serviceName }}
+servicePort: {{ .servicePort }}
+{{- else -}}
+service:
+  name: {{ .serviceName }}
+  port:
+    {{- if typeIs "string" .servicePort }}
+    name: {{ .servicePort }}
+    {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
+    number: {{ .servicePort | int }}
+    {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Print "true" if the API pathType field is supported
+Usage:
+{{ include "common.ingress.supportsPathType" . }}
+*/}}
+{{- define "common.ingress.supportsPathType" -}}
+{{- if (semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .)) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if the ingressClassname field is supported
+Usage:
+{{ include "common.ingress.supportsIngressClassname" . }}
+*/}}
+{{- define "common.ingress.supportsIngressClassname" -}}
+{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "false" -}}
+{{- else -}}
+{{- print "true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if cert-manager required annotations for TLS signed
+certificates are set in the Ingress annotations
+Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+Usage:
+{{ include "common.ingress.certManagerRequest" ( dict "annotations" .Values.path.to.the.ingress.annotations ) }}
+*/}}
+{{- define "common.ingress.certManagerRequest" -}}
+{{ if or (hasKey .annotations "cert-manager.io/cluster-issuer") (hasKey .annotations "cert-manager.io/issuer") }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_labels.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_labels.tpl
@@ -1,0 +1,18 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Kubernetes standard labels
+*/}}
+{{- define "common.labels.standard" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+helm.sh/chart: {{ include "common.names.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "common.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_names.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_names.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified dependency name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Usage:
+{{ include "common.names.dependency.fullname" (dict "chartName" "dependency-chart-name" "chartValues" .Values.dependency-chart "context" $) }}
+*/}}
+{{- define "common.names.dependency.fullname" -}}
+{{- if .chartValues.fullnameOverride -}}
+{{- .chartValues.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .chartName .chartValues.nameOverride -}}
+{{- if contains $name .context.Release.Name -}}
+{{- .context.Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .context.Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "common.names.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified app name adding the installation's namespace.
+*/}}
+{{- define "common.names.fullname.namespace" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) (include "common.names.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_secrets.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_secrets.tpl
@@ -1,0 +1,140 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate secret name.
+
+Usage:
+{{ include "common.secrets.name" (dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $) }}
+
+Params:
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - defaultNameSuffix - String - Optional. It is used only if we have several secrets in the same deployment.
+  - context - Dict - Required. The context for the template evaluation.
+*/}}
+{{- define "common.secrets.name" -}}
+{{- $name := (include "common.names.fullname" .context) -}}
+
+{{- if .defaultNameSuffix -}}
+{{- $name = printf "%s-%s" $name .defaultNameSuffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- with .existingSecret -}}
+{{- if not (typeIs "string" .) -}}
+{{- with .name -}}
+{{- $name = . -}}
+{{- end -}}
+{{- else -}}
+{{- $name = . -}}
+{{- end -}}
+{{- end -}}
+
+{{- printf "%s" $name -}}
+{{- end -}}
+
+{{/*
+Generate secret key.
+
+Usage:
+{{ include "common.secrets.key" (dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName") }}
+
+Params:
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - key - String - Required. Name of the key in the secret.
+*/}}
+{{- define "common.secrets.key" -}}
+{{- $key := .key -}}
+
+{{- if .existingSecret -}}
+  {{- if not (typeIs "string" .existingSecret) -}}
+    {{- if .existingSecret.keyMapping -}}
+      {{- $key = index .existingSecret.keyMapping $.key -}}
+    {{- end -}}
+  {{- end }}
+{{- end -}}
+
+{{- printf "%s" $key -}}
+{{- end -}}
+
+{{/*
+Generate secret password or retrieve one if already created.
+
+Usage:
+{{ include "common.secrets.passwords.manage" (dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - providedValues - List<String> - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - length - int - Optional - Length of the generated random password.
+  - strong - Boolean - Optional - Whether to add symbols to the generated random password.
+  - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
+  - context - Context - Required - Parent context.
+
+The order in which this function returns a secret password:
+  1. Already existing 'Secret' resource
+     (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
+  2. Password provided via the values.yaml
+     (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
+  3. Randomly generated secret password
+     (A new random secret password with the length specified in the 'length' parameter will be generated and returned)
+
+*/}}
+{{- define "common.secrets.passwords.manage" -}}
+
+{{- $password := "" }}
+{{- $subchart := "" }}
+{{- $chartName := default "" .chartName }}
+{{- $passwordLength := default 10 .length }}
+{{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
+{{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
+{{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data }}
+{{- if $secretData }}
+  {{- if hasKey $secretData .key }}
+    {{- $password = index $secretData .key }}
+  {{- else }}
+    {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
+  {{- end -}}
+{{- else if $providedPasswordValue }}
+  {{- $password = $providedPasswordValue | toString | b64enc | quote }}
+{{- else }}
+
+  {{- if .context.Values.enabled }}
+    {{- $subchart = $chartName }}
+  {{- end -}}
+
+  {{- $requiredPassword := dict "valueKey" $providedPasswordKey "secret" .secret "field" .key "subchart" $subchart "context" $.context -}}
+  {{- $requiredPasswordError := include "common.validations.values.single.empty" $requiredPassword -}}
+  {{- $passwordValidationErrors := list $requiredPasswordError -}}
+  {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $.context) -}}
+
+  {{- if .strong }}
+    {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
+    {{- $password = randAscii $passwordLength }}
+    {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
+    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc | quote }}
+  {{- else }}
+    {{- $password = randAlphaNum $passwordLength | b64enc | quote }}
+  {{- end }}
+{{- end -}}
+{{- printf "%s" $password -}}
+{{- end -}}
+
+{{/*
+Returns whether a previous generated secret already exists
+
+Usage:
+{{ include "common.secrets.exists" (dict "secret" "secret-name" "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - context - Context - Required - Parent context.
+*/}}
+{{- define "common.secrets.exists" -}}
+{{- $secret := (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
+{{- if $secret }}
+  {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_storage.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_storage.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return  the proper Storage Class
+{{ include "common.storage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
+*/}}
+{{- define "common.storage.class" -}}
+
+{{- $storageClass := .persistence.storageClass -}}
+{{- if .global -}}
+    {{- if .global.storageClass -}}
+        {{- $storageClass = .global.storageClass -}}
+    {{- end -}}
+{{- end -}}
+
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else }}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_tplvalues.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_utils.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_utils.tpl
@@ -1,0 +1,62 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Print instructions to get a secret value.
+Usage:
+{{ include "common.utils.secret.getvalue" (dict "secret" "secret-name" "field" "secret-value-field" "context" $) }}
+*/}}
+{{- define "common.utils.secret.getvalue" -}}
+{{- $varname := include "common.utils.fieldToEnvVar" . -}}
+export {{ $varname }}=$(kubectl get secret --namespace {{ .context.Release.Namespace | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 -d)
+{{- end -}}
+
+{{/*
+Build env var name given a field
+Usage:
+{{ include "common.utils.fieldToEnvVar" dict "field" "my-password" }}
+*/}}
+{{- define "common.utils.fieldToEnvVar" -}}
+  {{- $fieldNameSplit := splitList "-" .field -}}
+  {{- $upperCaseFieldNameSplit := list -}}
+
+  {{- range $fieldNameSplit -}}
+    {{- $upperCaseFieldNameSplit = append $upperCaseFieldNameSplit ( upper . ) -}}
+  {{- end -}}
+
+  {{ join "_" $upperCaseFieldNameSplit }}
+{{- end -}}
+
+{{/*
+Gets a value from .Values given
+Usage:
+{{ include "common.utils.getValueFromKey" (dict "key" "path.to.key" "context" $) }}
+*/}}
+{{- define "common.utils.getValueFromKey" -}}
+{{- $splitKey := splitList "." .key -}}
+{{- $value := "" -}}
+{{- $latestObj := $.context.Values -}}
+{{- range $splitKey -}}
+  {{- if not $latestObj -}}
+    {{- printf "please review the entire path of '%s' exists in values" $.key | fail -}}
+  {{- end -}}
+  {{- $value = ( index $latestObj . ) -}}
+  {{- $latestObj = $value -}}
+{{- end -}}
+{{- printf "%v" (default "" $value) -}} 
+{{- end -}}
+
+{{/*
+Returns first .Values key with a defined value or first of the list if all non-defined
+Usage:
+{{ include "common.utils.getKeyFromList" (dict "keys" (list "path.to.key1" "path.to.key2") "context" $) }}
+*/}}
+{{- define "common.utils.getKeyFromList" -}}
+{{- $key := first .keys -}}
+{{- $reverseKeys := reverse .keys }}
+{{- range $reverseKeys }}
+  {{- $value := include "common.utils.getValueFromKey" (dict "key" . "context" $.context ) }}
+  {{- if $value -}}
+    {{- $key = . }}
+  {{- end -}}
+{{- end -}}
+{{- printf "%s" $key -}} 
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_warnings.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_warnings.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Warning about using rolling tag.
+Usage:
+{{ include "common.warnings.rollingTag" .Values.path.to.the.imageRoot }}
+*/}}
+{{- define "common.warnings.rollingTag" -}}
+
+{{- if and (contains "bitnami/" .repository) (not (.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_cassandra.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_cassandra.tpl
@@ -1,0 +1,72 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate Cassandra required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.cassandra.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where Cassandra values are stored, e.g: "cassandra-passwords-secret"
+  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.cassandra.passwords" -}}
+  {{- $existingSecret := include "common.cassandra.values.existingSecret" . -}}
+  {{- $enabled := include "common.cassandra.values.enabled" . -}}
+  {{- $dbUserPrefix := include "common.cassandra.values.key.dbUser" . -}}
+  {{- $valueKeyPassword := printf "%s.password" $dbUserPrefix -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "cassandra-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.cassandra.values.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
+*/}}
+{{- define "common.cassandra.values.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.cassandra.dbUser.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.dbUser.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled cassandra.
+
+Usage:
+{{ include "common.cassandra.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.cassandra.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.cassandra.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key dbUser
+
+Usage:
+{{ include "common.cassandra.values.key.dbUser" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
+*/}}
+{{- define "common.cassandra.values.key.dbUser" -}}
+  {{- if .subchart -}}
+    cassandra.dbUser
+  {{- else -}}
+    dbUser
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mariadb.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mariadb.tpl
@@ -1,0 +1,103 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate MariaDB required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.mariadb.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where MariaDB values are stored, e.g: "mysql-passwords-secret"
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.mariadb.passwords" -}}
+  {{- $existingSecret := include "common.mariadb.values.auth.existingSecret" . -}}
+  {{- $enabled := include "common.mariadb.values.enabled" . -}}
+  {{- $architecture := include "common.mariadb.values.architecture" . -}}
+  {{- $authPrefix := include "common.mariadb.values.key.auth" . -}}
+  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
+  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
+  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
+  {{- $valueKeyReplicationPassword := printf "%s.replicationPassword" $authPrefix -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mariadb-root-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+    {{- if not (empty $valueUsername) -}}
+        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mariadb-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+    {{- end -}}
+
+    {{- if (eq $architecture "replication") -}}
+        {{- $requiredReplicationPassword := dict "valueKey" $valueKeyReplicationPassword "secret" .secret "field" "mariadb-replication-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mariadb.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mariadb.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mariadb.
+
+Usage:
+{{ include "common.mariadb.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mariadb.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mariadb.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mariadb.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mariadb.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mariadb.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
+*/}}
+{{- define "common.mariadb.values.key.auth" -}}
+  {{- if .subchart -}}
+    mariadb.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mongodb.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mongodb.tpl
@@ -1,0 +1,108 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate MongoDB&reg; required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.mongodb.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where MongoDB&reg; values are stored, e.g: "mongodb-passwords-secret"
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.mongodb.passwords" -}}
+  {{- $existingSecret := include "common.mongodb.values.auth.existingSecret" . -}}
+  {{- $enabled := include "common.mongodb.values.enabled" . -}}
+  {{- $authPrefix := include "common.mongodb.values.key.auth" . -}}
+  {{- $architecture := include "common.mongodb.values.architecture" . -}}
+  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
+  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
+  {{- $valueKeyDatabase := printf "%s.database" $authPrefix -}}
+  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
+  {{- $valueKeyReplicaSetKey := printf "%s.replicaSetKey" $authPrefix -}}
+  {{- $valueKeyAuthEnabled := printf "%s.enabled" $authPrefix -}}
+
+  {{- $authEnabled := include "common.utils.getValueFromKey" (dict "key" $valueKeyAuthEnabled "context" .context) -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") (eq $authEnabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mongodb-root-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+    {{- $valueDatabase := include "common.utils.getValueFromKey" (dict "key" $valueKeyDatabase "context" .context) }}
+    {{- if and $valueUsername $valueDatabase -}}
+        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mongodb-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+    {{- end -}}
+
+    {{- if (eq $architecture "replicaset") -}}
+        {{- $requiredReplicaSetKey := dict "valueKey" $valueKeyReplicaSetKey "secret" .secret "field" "mongodb-replica-set-key" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredReplicaSetKey -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mongodb.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDb is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mongodb.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mongodb.
+
+Usage:
+{{ include "common.mongodb.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mongodb.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mongodb.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mongodb.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.key.auth" -}}
+  {{- if .subchart -}}
+    mongodb.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mongodb.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
+*/}}
+{{- define "common.mongodb.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mongodb.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mysql.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mysql.tpl
@@ -1,0 +1,103 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate MySQL required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.mysql.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where MySQL values are stored, e.g: "mysql-passwords-secret"
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.mysql.passwords" -}}
+  {{- $existingSecret := include "common.mysql.values.auth.existingSecret" . -}}
+  {{- $enabled := include "common.mysql.values.enabled" . -}}
+  {{- $architecture := include "common.mysql.values.architecture" . -}}
+  {{- $authPrefix := include "common.mysql.values.key.auth" . -}}
+  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
+  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
+  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
+  {{- $valueKeyReplicationPassword := printf "%s.replicationPassword" $authPrefix -}}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mysql-root-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+    {{- if not (empty $valueUsername) -}}
+        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mysql-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+    {{- end -}}
+
+    {{- if (eq $architecture "replication") -}}
+        {{- $requiredReplicationPassword := dict "valueKey" $valueKeyReplicationPassword "secret" .secret "field" "mysql-replication-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.mysql.values.auth.existingSecret" (dict "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.auth.existingSecret" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.auth.existingSecret | quote -}}
+  {{- else -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled mysql.
+
+Usage:
+{{ include "common.mysql.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.mysql.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.mysql.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for architecture
+
+Usage:
+{{ include "common.mysql.values.architecture" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.architecture" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mysql.architecture -}}
+  {{- else -}}
+    {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key auth
+
+Usage:
+{{ include "common.mysql.values.key.auth" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
+*/}}
+{{- define "common.mysql.values.key.auth" -}}
+  {{- if .subchart -}}
+    mysql.auth
+  {{- else -}}
+    auth
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_postgresql.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_postgresql.tpl
@@ -1,0 +1,129 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate PostgreSQL required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.postgresql.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where postgresql values are stored, e.g: "postgresql-passwords-secret"
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.postgresql.passwords" -}}
+  {{- $existingSecret := include "common.postgresql.values.existingSecret" . -}}
+  {{- $enabled := include "common.postgresql.values.enabled" . -}}
+  {{- $valueKeyPostgresqlPassword := include "common.postgresql.values.key.postgressPassword" . -}}
+  {{- $valueKeyPostgresqlReplicationEnabled := include "common.postgresql.values.key.replicationPassword" . -}}
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+    {{- $requiredPostgresqlPassword := dict "valueKey" $valueKeyPostgresqlPassword "secret" .secret "field" "postgresql-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlPassword -}}
+
+    {{- $enabledReplication := include "common.postgresql.values.enabled.replication" . -}}
+    {{- if (eq $enabledReplication "true") -}}
+        {{- $requiredPostgresqlReplicationPassword := dict "valueKey" $valueKeyPostgresqlReplicationEnabled "secret" .secret "field" "postgresql-replication-password" -}}
+        {{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlReplicationPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to decide whether evaluate global values.
+
+Usage:
+{{ include "common.postgresql.values.use.global" (dict "key" "key-of-global" "context" $) }}
+Params:
+  - key - String - Required. Field to be evaluated within global, e.g: "existingSecret"
+*/}}
+{{- define "common.postgresql.values.use.global" -}}
+  {{- if .context.Values.global -}}
+    {{- if .context.Values.global.postgresql -}}
+      {{- index .context.Values.global.postgresql .key | quote -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for existingSecret.
+
+Usage:
+{{ include "common.postgresql.values.existingSecret" (dict "context" $) }}
+*/}}
+{{- define "common.postgresql.values.existingSecret" -}}
+  {{- $globalValue := include "common.postgresql.values.use.global" (dict "key" "existingSecret" "context" .context) -}}
+
+  {{- if .subchart -}}
+    {{- default (.context.Values.postgresql.existingSecret | quote) $globalValue -}}
+  {{- else -}}
+    {{- default (.context.Values.existingSecret | quote) $globalValue -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled postgresql.
+
+Usage:
+{{ include "common.postgresql.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.postgresql.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.postgresql.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key postgressPassword.
+
+Usage:
+{{ include "common.postgresql.values.key.postgressPassword" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.key.postgressPassword" -}}
+  {{- $globalValue := include "common.postgresql.values.use.global" (dict "key" "postgresqlUsername" "context" .context) -}}
+
+  {{- if not $globalValue -}}
+    {{- if .subchart -}}
+      postgresql.postgresqlPassword
+    {{- else -}}
+      postgresqlPassword
+    {{- end -}}
+  {{- else -}}
+    global.postgresql.postgresqlPassword
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled.replication.
+
+Usage:
+{{ include "common.postgresql.values.enabled.replication" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.enabled.replication" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.postgresql.replication.enabled -}}
+  {{- else -}}
+    {{- printf "%v" .context.Values.replication.enabled -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for the key replication.password.
+
+Usage:
+{{ include "common.postgresql.values.key.replicationPassword" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
+*/}}
+{{- define "common.postgresql.values.key.replicationPassword" -}}
+  {{- if .subchart -}}
+    postgresql.replication.password
+  {{- else -}}
+    replication.password
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_redis.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_redis.tpl
@@ -1,0 +1,76 @@
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate Redis&reg; required passwords are not empty.
+
+Usage:
+{{ include "common.validations.values.redis.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
+Params:
+  - secret - String - Required. Name of the secret where redis values are stored, e.g: "redis-passwords-secret"
+  - subchart - Boolean - Optional. Whether redis is used as subchart or not. Default: false
+*/}}
+{{- define "common.validations.values.redis.passwords" -}}
+  {{- $enabled := include "common.redis.values.enabled" . -}}
+  {{- $valueKeyPrefix := include "common.redis.values.keys.prefix" . -}}
+  {{- $standarizedVersion := include "common.redis.values.standarized.version" . }}
+
+  {{- $existingSecret := ternary (printf "%s%s" $valueKeyPrefix "auth.existingSecret") (printf "%s%s" $valueKeyPrefix "existingSecret") (eq $standarizedVersion "true") }}
+  {{- $existingSecretValue := include "common.utils.getValueFromKey" (dict "key" $existingSecret "context" .context) }}
+
+  {{- $valueKeyRedisPassword := ternary (printf "%s%s" $valueKeyPrefix "auth.password") (printf "%s%s" $valueKeyPrefix "password") (eq $standarizedVersion "true") }}
+  {{- $valueKeyRedisUseAuth := ternary (printf "%s%s" $valueKeyPrefix "auth.enabled") (printf "%s%s" $valueKeyPrefix "usePassword") (eq $standarizedVersion "true") }}
+
+  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
+    {{- $requiredPasswords := list -}}
+
+    {{- $useAuth := include "common.utils.getValueFromKey" (dict "key" $valueKeyRedisUseAuth "context" .context) -}}
+    {{- if eq $useAuth "true" -}}
+      {{- $requiredRedisPassword := dict "valueKey" $valueKeyRedisPassword "secret" .secret "field" "redis-password" -}}
+      {{- $requiredPasswords = append $requiredPasswords $requiredRedisPassword -}}
+    {{- end -}}
+
+    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right value for enabled redis.
+
+Usage:
+{{ include "common.redis.values.enabled" (dict "context" $) }}
+*/}}
+{{- define "common.redis.values.enabled" -}}
+  {{- if .subchart -}}
+    {{- printf "%v" .context.Values.redis.enabled -}}
+  {{- else -}}
+    {{- printf "%v" (not .context.Values.enabled) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Auxiliary function to get the right prefix path for the values
+
+Usage:
+{{ include "common.redis.values.key.prefix" (dict "subchart" "true" "context" $) }}
+Params:
+  - subchart - Boolean - Optional. Whether redis is used as subchart or not. Default: false
+*/}}
+{{- define "common.redis.values.keys.prefix" -}}
+  {{- if .subchart -}}redis.{{- else -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Checks whether the redis chart's includes the standarizations (version >= 14)
+
+Usage:
+{{ include "common.redis.values.standarized.version" (dict "context" $) }}
+*/}}
+{{- define "common.redis.values.standarized.version" -}}
+
+  {{- $standarizedAuth := printf "%s%s" (include "common.redis.values.keys.prefix" .) "auth" -}}
+  {{- $standarizedAuthValues := include "common.utils.getValueFromKey" (dict "key" $standarizedAuth "context" .context) }}
+
+  {{- if $standarizedAuthValues -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_validations.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_validations.tpl
@@ -1,0 +1,46 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Validate values must not be empty.
+
+Usage:
+{{- $validateValueConf00 := (dict "valueKey" "path.to.value" "secret" "secretName" "field" "password-00") -}}
+{{- $validateValueConf01 := (dict "valueKey" "path.to.value" "secret" "secretName" "field" "password-01") -}}
+{{ include "common.validations.values.empty" (dict "required" (list $validateValueConf00 $validateValueConf01) "context" $) }}
+
+Validate value params:
+  - valueKey - String - Required. The path to the validating value in the values.yaml, e.g: "mysql.password"
+  - secret - String - Optional. Name of the secret where the validating value is generated/stored, e.g: "mysql-passwords-secret"
+  - field - String - Optional. Name of the field in the secret data, e.g: "mysql-password"
+*/}}
+{{- define "common.validations.values.multiple.empty" -}}
+  {{- range .required -}}
+    {{- include "common.validations.values.single.empty" (dict "valueKey" .valueKey "secret" .secret "field" .field "context" $.context) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Validate a value must not be empty.
+
+Usage:
+{{ include "common.validations.value.empty" (dict "valueKey" "mariadb.password" "secret" "secretName" "field" "my-password" "subchart" "subchart" "context" $) }}
+
+Validate value params:
+  - valueKey - String - Required. The path to the validating value in the values.yaml, e.g: "mysql.password"
+  - secret - String - Optional. Name of the secret where the validating value is generated/stored, e.g: "mysql-passwords-secret"
+  - field - String - Optional. Name of the field in the secret data, e.g: "mysql-password"
+  - subchart - String - Optional - Name of the subchart that the validated password is part of.
+*/}}
+{{- define "common.validations.values.single.empty" -}}
+  {{- $value := include "common.utils.getValueFromKey" (dict "key" .valueKey "context" .context) }}
+  {{- $subchart := ternary "" (printf "%s." .subchart) (empty .subchart) }}
+
+  {{- if not $value -}}
+    {{- $varname := "my-value" -}}
+    {{- $getCurrentValue := "" -}}
+    {{- if and .secret .field -}}
+      {{- $varname = include "common.utils.fieldToEnvVar" . -}}
+      {{- $getCurrentValue = printf " To get the current value:\n\n        %s\n" (include "common.utils.secret.getvalue" .) -}}
+    {{- end -}}
+    {{- printf "\n    '%s' must not be empty, please add '--set %s%s=$%s' to the command.%s" .valueKey $subchart .valueKey $varname $getCurrentValue -}}
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/values.yaml
@@ -1,0 +1,5 @@
+## bitnami/common
+## It is required by CI/CD tools and processes.
+## @skip exampleValue
+##
+exampleValue: common-chart

--- a/agrold-javaweb/charts/agrold-javaweb/templates/NOTES.txt
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/NOTES.txt
@@ -1,0 +1,57 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.ingress.enabled }}
+
+1. Get the Tomcat URL and associate its hostname to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Tomcat URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+{{- else }}
+
+1. Get the Tomcat URL by running:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Tomcat URL:            http://$NODE_IP:$NODE_PORT"
+  echo "Tomcat Management URL: http://$NODE_IP:$NODE_PORT/manager"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  {{- $port:=.Values.service.ports.http | toString }}
+  echo "Tomcat URL:            http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.ports.http }}{{ end }}/"
+  echo "Tomcat Management URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.ports.http }}{{ end }}/manager"
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 8080:{{ .Values.service.ports.http }} &
+  echo "Tomcat URL:            http://127.0.0.1:8080/"
+  echo "Tomcat Management URL: http://127.0.0.1:8080/manager"
+
+{{- end }}
+{{- end }}
+
+2. Login with the following credentials
+
+  echo Username: {{ .Values.tomcatUsername }}
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.tomcat-password}" | base64 -d)
+
+{{- include "tomcat.checkRollingTags" . }}
+{{- $passwordValidationErrors := list -}}
+{{- $secretName := include "common.names.fullname" . -}}
+{{- $requiredTomcatPassword := dict "valueKey" "tomcatPassword" "secret" $secretName "field" "tomcat-password" "context" $ -}}
+{{- $requiredTomcatPasswordError := include "common.validations.values.single.empty" $requiredTomcatPassword -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $requiredTomcatPasswordError -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
+{{- include "tomcat.validateValues" . -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the proper Tomcat image name
+*/}}
+{{- define "tomcat.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the Tomcat ports map
+*/}}
+{{- define "tomcat.ports" -}}
+- port: {{ .Values.containerPorts.http }}
+  protocol: TCP
+{{- range .Values.containerExtraPorts }}
+- port: {{ include "common.tplvalues.render" (dict "value" .containerPort "context" $) }}
+  protocol: TCP
+{{- end }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tomcat.fullname" -}}
+{{- include "common.names.fullname" . -}}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "tomcat.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "tomcat.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.metrics.jmx.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "tomcat.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tomcat.pvc" -}}
+{{- coalesce .Values.persistence.existingClaim (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Transform a dict of key-value pairs into a string of -Dkey=value arguments
+*/}}
+{{- define "tomcat.flattenIntoSysProperties" -}}
+{{- $result := "" }}
+{{- range $key, $value := . }}
+  {{- $result = print $result "-Dagrold." $key "=" ($value | quote) " " }}
+{{- end }}
+{{- trimSuffix " " $result }}
+{{- end -}}
+
+{{/*
+Return the proper CATALINA_OPTS value
+*/}}
+{{- define "tomcat.catalinaOpts" -}}
+{{- $agrold := include "tomcat.flattenIntoSysProperties" .Values.agroldProperties -}}
+{{- if .Values.metrics.jmx.enabled -}}
+{{- default "" (cat .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts (printf "-Dagrold.baseurl=%q" (ternary (print "https://" .Values.ingress.hostname) (print "http://" .Values.ingress.hostname) .Values.ingress.tls)) $agrold) | trim  -}}
+{{- else -}}
+{{- default "" (cat .Values.catalinaOpts (printf "-Dagrold.baseurl=%q" (ternary (print "https://" .Values.ingress.hostname) (print "http://" .Values.ingress.hostname) .Values.ingress.tls)) $agrold) | trim -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper JMX exporter image name
+*/}}
+{{- define "tomcat.metrics.jmx.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.metrics.jmx.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the tomcat jmx configuration configmap
+*/}}
+{{- define "tomcat.metrics.jmx.configmapName" -}}
+{{- if .Values.metrics.jmx.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.metrics.jmx.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-jmx-configuration" (include "tomcat.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "tomcat.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "tomcat.validateValues.jmxConfig" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if jmx metrics is enabled, then either metrics.jmx.config or metrics.jmx.existingConfigmap must be set.
+*/}}
+{{- define "tomcat.validateValues.jmxConfig" -}}
+    {{- if and .Values.metrics.jmx.enabled (not .Values.metrics.jmx.config)  (not .Values.metrics.jmx.existingConfigmap) -}}
+tomcat: metrics.jmx.enabled
+    In order to enable JMX metrics, you also need to provide
+    the prometheus/jmx_exporter configuration or
+    provide an existing ConfigMap.
+  {{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/_pod.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/_pod.tpl
@@ -1,0 +1,194 @@
+{{/*
+Pod Spec
+*/}}
+{{- define "tomcat.pod" -}}
+{{- include "tomcat.imagePullSecrets" . }}
+{{- if .Values.hostAliases }}
+hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 2 }}
+{{- end }}
+{{- if .Values.affinity }}
+affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 2 }}
+{{- else }}
+affinity:
+  podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 4 }}
+  podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 4 }}
+  nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 4 }}
+{{- end }}
+{{- if .Values.schedulerName }}
+schedulerName: {{ .Values.schedulerName | quote }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 2 }}
+{{- end }}
+{{- if .Values.tolerations }}
+tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 2 }}
+{{- end }}
+{{- if .Values.podSecurityContext.enabled }}
+securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 2 }}
+{{- end }}
+{{- if .Values.topologySpreadConstraints }}
+topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" $) | nindent 2 }}
+{{- end }}
+initContainers:
+{{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+  - name: volume-permissions
+    image: {{ template "tomcat.volumePermissions.image" . }}
+    imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+    command:
+      - /bin/bash
+      - -ec
+      - |
+          chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/tomcat
+    securityContext:
+      runAsUser: 0
+    {{- if .Values.volumePermissions.resources }}
+    resources: {{- toYaml .Values.volumePermissions.resources | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: data
+        mountPath: /bitnami/tomcat
+{{- end }}
+{{- if .Values.initContainers }}
+{{ include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) }}
+{{- end }}
+containers:
+  - name: tomcat
+    image: {{ template "tomcat.image" . }}
+    imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+    {{- if .Values.containerSecurityContext.enabled }}
+    securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 6 }}
+    {{- end }}
+    {{- if .Values.command }}
+    command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if .Values.args }}
+    args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 6 }}
+    {{- end }}
+    env:
+      - name: BITNAMI_DEBUG
+        value: {{ ternary "true" "false" .Values.image.debug | quote }}
+      - name: TOMCAT_USERNAME
+        value: {{ .Values.tomcatUsername | quote }}
+      - name: TOMCAT_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "common.names.fullname" . }}
+            key: tomcat-password
+      - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
+        value: {{ .Values.tomcatAllowRemoteManagement | quote }}
+      - name: CATALINA_OPTS
+        value: {{ include "tomcat.catalinaOpts" . | quote }}
+      {{- if .Values.extraEnvVars }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 6 }}
+      {{- end }}
+    {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+    envFrom:
+      {{- if .Values.extraEnvVarsCM }}
+      - configMapRef:
+          name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+      {{- end }}
+      {{- if .Values.extraEnvVarsSecret }}
+      - secretRef:
+          name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.lifecycleHooks }}
+    lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 6 }}
+    {{- end }}
+    ports:
+      - name: http
+        containerPort: {{ .Values.containerPorts.http }}
+      {{- if .Values.containerExtraPorts }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.containerExtraPorts "context" $) | nindent 6 }}
+      {{- end }}
+    {{- if .Values.customLivenessProbe }}
+    livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 6 }}
+    {{- else if .Values.livenessProbe.enabled }}
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+        {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if .Values.customReadinessProbe }}
+    readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 6 }}
+    {{- else if .Values.readinessProbe.enabled }}
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
+      {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if .Values.customStartupProbe }}
+    startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 6 }}
+    {{- else if .Values.startupProbe.enabled }}
+    startupProbe:
+      httpGet:
+        path: /
+        port: http
+      {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if .Values.resources }}
+    resources: {{- toYaml .Values.resources | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: data
+        mountPath: /bitnami/tomcat
+      {{- if .Values.extraVolumeMounts }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 6 }}
+      {{- end }}
+  {{- if .Values.metrics.jmx.enabled }}
+  - name: jmx-exporter
+    image: {{ template "tomcat.metrics.jmx.image" . }}
+    imagePullPolicy: {{ .Values.metrics.jmx.image.pullPolicy | quote }}
+    {{- if .Values.metrics.jmx.containerSecurityContext.enabled }}
+    securityContext: {{- omit .Values.metrics.jmx.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+    {{- end }}
+    command:
+      - java
+      - -XX:+UnlockExperimentalVMOptions
+      - -XX:+UseCGroupMemoryLimitForHeap
+      - -XX:MaxRAMFraction=1
+      - -XshowSettings:vm
+      - -jar
+      - jmx_prometheus_httpserver.jar
+      - {{ .Values.metrics.jmx.ports.metrics | quote }}
+      - /etc/jmx-tomcat/jmx-tomcat-prometheus.yml
+    ports:
+    {{- range $key, $val := .Values.metrics.jmx.ports }}
+      - name: {{ $key }}
+        containerPort: {{ $val }}
+    {{- end }}
+    {{- if .Values.metrics.jmx.resources }}
+    resources: {{- toYaml .Values.metrics.jmx.resources | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: jmx-config
+        mountPath: /etc/jmx-tomcat
+  {{- end }}
+  {{- if .Values.sidecars }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 2 }}
+  {{- end }}
+volumes:
+  {{- if (eq .Values.deployment.type "deployment") }}
+  {{- if and .Values.persistence.enabled }}
+  - name: data
+    persistentVolumeClaim:
+      claimName: {{ template "tomcat.pvc" . }}
+  {{- else }}
+  - name: data
+    emptyDir: {}
+  {{- end }}
+  {{- end }}
+  {{- if and .Values.metrics.jmx.enabled (or .Values.metrics.jmx.config .Values.metrics.jmx.existingConfigmap) }}
+  - configMap:
+      name: {{ include "tomcat.metrics.jmx.configmapName" . }}
+    name: jmx-config
+  {{- end }}
+  {{- if .Values.extraVolumes }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 2 }}
+  {{- end }}
+{{- if .Values.extraPodSpec }}
+{{- include "common.tplvalues.render" (dict "value" .Values.extraPodSpec "context" $) }}
+{{- end }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/_pod.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/_pod.tpl
@@ -77,7 +77,10 @@ containers:
       - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
         value: {{ .Values.tomcatAllowRemoteManagement | quote }}
       - name: CATALINA_OPTS
-        value: {{ include "tomcat.catalinaOpts" . | quote }}
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "common.names.fullname" . }}
+            key: catalinaOpts
       {{- if .Values.extraEnvVars }}
       {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 6 }}
       {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/deployment.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/deployment.yaml
@@ -1,0 +1,29 @@
+{{ if (or (not .Values.persistence.enabled) (eq .Values.deployment.type "deployment")) }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec: {{- include "tomcat.pod" . | nindent 6 }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/extra-list.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/ingress.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/ingress.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
+  annotations:
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraPaths  "context" $) | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+    {{- if .Values.ingress.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/jmx-configmap.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/jmx-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.metrics.jmx.enabled .Values.metrics.jmx.config (not .Values.metrics.jmx.existingConfigmap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "tomcat.fullname" . }}-jmx-configuration
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  jmx-tomcat-prometheus.yml: |-
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.jmx.config "context" $ ) | nindent 4 }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/networkpolicy.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
+  ingress:
+    # Allow inbound connections
+    - ports: {{- include "tomcat.ports" . | nindent 8 }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "common.names.fullname" . }}-client: "true"
+          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
+          namespaceSelector:
+{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
+          {{- end }}
+    # Allow communication between Tomcat's POD
+        - podSelector:
+            matchLabels:
+            {{- include "common.labels.matchLabels" . | nindent 14 }}
+      {{- end }}
+    {{- if .Values.metrics.jmx.enabled }}
+    # Allow prometheus scrapes
+    - ports:
+        - port: {{ .Values.metrics.jmx.ports.metrics }}
+    {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/podmonitor.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/podmonitor.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.metrics.jmx.enabled .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.podMonitor.namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.podMonitor.additionalLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podMonitor.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.metrics.podMonitor.podTargetLabels }}
+  podTargetLabels: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podMonitor.podTargetLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  podMetricsEndpoints:
+{{- range $key, $val := .Values.metrics.jmx.ports }}
+    - port: {{ $key | quote }}
+      path: /metrics
+      {{- if $.Values.metrics.podMonitor.interval }}
+      interval: {{ $.Values.metrics.podMonitor.interval }}
+      {{- end }}
+      {{- if $.Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ $.Values.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if $.Values.metrics.podMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" (dict "value" $.Values.metrics.podMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+{{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/prometheusrule.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/prometheusrule.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.jmx.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "common.names.fullname" . }}
+{{- with .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+  {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- with .Values.metrics.prometheusRule.additionalLabels }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+{{- with .Values.metrics.prometheusRule.rules }}
+  groups:
+    - name: {{ template "common.names.name" $ }}
+      rules: {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/pvc.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "deployment") -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{- if .Values.tomcatPassword }}
+  tomcat-password: {{ .Values.tomcatPassword | b64enc | quote }}
+  {{- else }}
+  tomcat-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
@@ -17,3 +17,4 @@ data:
   {{- else }}
   tomcat-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
+  catalinaOpts: {{ include "tomcat.catalinaOpts" . | b64enc | quote }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/statefulset.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/statefulset.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset") }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- if .Values.podManagementPolicy }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
+  serviceName: {{ template "common.names.fullname" . }}-headless
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec: {{- include "tomcat.pod" . | nindent 6 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+        {{- with .Values.persistence.selectorLabels }}
+        selector:
+          matchLabels: {{- toYaml . | nindent 10 }}
+        {{- end }}
+    {{- if .Values.extraVolumeClaimTemplates }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeClaimTemplates "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/svc-headless.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/svc-headless.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/svc.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/svc.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      targetPort: http
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/tls-secrets.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/tls-secrets.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "tomcat-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/values.yaml
@@ -25,6 +25,8 @@ agroldProperties:
   db_connection_url: someurl
   db_username: user
   db_password: password
+  rf_link: https://rf.someurl.fr
+  description: ""
 
 ## @section Common parameters
 ##

--- a/agrold-javaweb/charts/agrold-javaweb/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/values.yaml
@@ -1,0 +1,781 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: "ghcr.io/southgreenplatform/agrold:2.0.0"
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+
+# use this to configure agrold you can read it's configuration at https://github.com/SouthGreenPlatform/AgroLD_webapp/blob/master/agrold-javaweb/README.md#param%C3%A8tres
+
+agroldProperties: 
+  # The property below is set to ingress.hostname, set this value to override it
+  # baseurl: "http://agrold.org"
+  db_connection_url: someurl
+  db_username: user
+  db_password: password
+
+## @section Common parameters
+##
+
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
+##
+kubeVersion: ""
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname template
+##
+fullnameOverride: ""
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: [ ]
+## @section Tomcat parameters
+##
+
+## Bitnami Tomcat image version
+## ref: https://hub.docker.com/r/bitnami/tomcat/tags/
+## @param image.registry Tomcat image registry
+## @param image.repository Tomcat image repository
+## @param image.tag Tomcat image tag (immutable tags are recommended)
+## @param image.digest Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Tomcat image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Specify if debug logs should be enabled
+##
+image:
+  registry: docker.io
+  repository: bitnami/tomcat
+  tag: 8.5.83-debian-11-r14
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
+## @param hostAliases Deployment pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param tomcatUsername Tomcat admin user
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
+##
+tomcatUsername: manager
+## @param tomcatPassword Tomcat admin password
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
+##
+tomcatPassword: "password"
+## @param tomcatAllowRemoteManagement Enable remote access to management interface
+## ref: https://github.com/bitnami/charts/tree/master/bitnami/tomcat#configuration
+##
+tomcatAllowRemoteManagement: 1
+## @param catalinaOpts Java runtime option used by tomcat JVM
+##
+catalinaOpts: ""
+## @param command Override default container command (useful when using custom images)
+##
+command: []
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param extraEnvVars Extra environment variables to be set on Tomcat container
+## Example:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
+##
+extraEnvVarsSecret: ""
+
+## @section Tomcat deployment parameters
+##
+
+## @param replicaCount Specify number of Tomcat replicas
+##
+replicaCount: 1
+## Deployment
+##
+deployment:
+  ## @param deployment.type Use Deployment or StatefulSet
+  ##
+  type: deployment
+## Strategy to use to update Pods
+##
+updateStrategy:
+  ## @param updateStrategy.type StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+## @param containerPorts.http HTTP port to expose at container level
+##
+containerPorts:
+  http: 8080
+## @param containerExtraPorts Extra ports to expose at container level
+##
+## Example:
+## containerExtraPorts:
+##  - name: ajp
+##    containerPort: 8081
+##
+containerExtraPorts: []
+## Tomcat pods' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param podSecurityContext.enabled Enable Tomcat pods' Security Context
+## @param podSecurityContext.fsGroup Set Tomcat pod's Security Context fsGroup
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+## Tomcat containers' SecurityContext
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param containerSecurityContext.enabled Enable Tomcat containers' SecurityContext
+## @param containerSecurityContext.runAsUser User ID for the Tomcat container
+## @param containerSecurityContext.runAsNonRoot Force user to be root in Tomcat container
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+## Tomcat containers' resource requests and limits
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the Tomcat container
+## @param resources.requests [object] The requested resources for the Tomcat container
+##
+resources:
+  ## Example:
+  ## limits:
+  ##    cpu: 500m
+  ##    memory: 1Gi
+  ##
+  limits: {}
+  requests:
+    cpu: 300m
+    memory: 512Mi
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  failureThreshold: 6
+  timeoutSeconds: 5
+  successThreshold: 1
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  failureThreshold: 3
+  timeoutSeconds: 3
+  successThreshold: 1
+## Configure extra options for startup probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-startup-probes/#configure-probes
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  failureThreshold: 3
+  timeoutSeconds: 3
+  successThreshold: 1
+## @param customLivenessProbe Override default liveness probe
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Override default readiness probe
+##
+customReadinessProbe: {}
+## @param customStartupProbe Override default startup probe
+##
+customStartupProbe: {}
+## @param podLabels Extra labels for Tomcat pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param podAnnotations Annotations for Tomcat pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+## @param affinity Affinity for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param schedulerName Alternative scheduler
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param lifecycleHooks [object] Override default etcd container hooks
+##
+lifecycleHooks: {}
+## @param podManagementPolicy podManagementPolicy to manage scaling operation of pods (only in StatefulSet mode)
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+##
+podManagementPolicy: ""
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: []
+## @param extraPodSpec Optionally specify extra PodSpec
+##
+extraPodSpec: {}
+## @param extraVolumes Optionally specify extra list of additional volumes for Tomcat pods in Deployment
+##
+extraVolumes: []
+  # - name: webapps
+  #   configMap:
+  #     name: apps 
+
+## @param extraVolumeClaimTemplates Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet
+##
+extraVolumeClaimTemplates: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Tomcat container(s)
+##
+extraVolumeMounts: []
+  # - name: webapps
+  #   mountPath: /mnt
+
+## @param initContainers Add init containers to the Tomcat pods.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: []
+## @param sidecars Add sidecars to the Tomcat pods.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## @param persistence.enabled Enable persistence
+  ##
+  enabled: true
+  ## @param persistence.storageClass PVC Storage Class for Tomcat volume
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  ## @param persistence.annotations Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## @param persistence.accessModes PVC Access Modes for Tomcat volume
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.size PVC Storage Request for Tomcat volume
+  ##
+  size: 8Gi
+  ## @param persistence.existingClaim An Existing PVC name for Tomcat volume
+  ##
+  existingClaim: ""
+  ## @param persistence.selectorLabels Selector labels to use in volume claim template in statefulset
+  ## Applicable when deployment.type is statefulset
+  ##
+  selectorLabels: {}
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to every tomcat port defined on containerPort and containerExtraPorts.
+  ## When true, tomcat will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the tomcat.
+  ## But sometimes, we want the tomcat to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
+## @section Traffic Exposure parameters
+##
+
+## Service parameters
+##
+service:
+  ## @param service.type Kubernetes Service type
+  ## For minikube, set this to NodePort, elsewhere use LoadBalancer
+  ##
+  type: ClusterIP
+  ## @param service.ports.http Service HTTP port
+  ##
+  ports:
+    http: 80
+  ## @param service.nodePorts.http Kubernetes http node port
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ""
+  ## @param service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+  ##
+  extraPorts: []
+  ## @param service.loadBalancerIP Port Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank
+  ##
+  loadBalancerIP: ""
+  ## @param service.clusterIP Service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.loadBalancerSourceRanges Service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy Enable client source IP preservation
+  ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.annotations Annotations for Tomcat service
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  ## @param service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+  ## If "ClientIP", consecutive client requests will be directed to the same Pod
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+  ##
+  sessionAffinity: None
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
+## Ingress configuratiom
+##
+ingress:
+  ## @param ingress.enabled Enable ingress controller resource
+  ##
+  enabled: true
+  ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
+  ## certManager: false
+  ##
+
+  ## @param ingress.hostname Default host for the ingress resource
+  ##
+  hostname: vmagrold-proto
+  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## Use this parameter to set the required annotations for cert-manager, see
+  ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+  ##
+  ## e.g:
+  ## annotations:
+  ##   kubernetes.io/ingress.class: nginx
+  ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+  ##
+  annotations: {}
+  ## @param ingress.tls Enable TLS configuration for the hostname defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret, rely on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
+  ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## Example:
+  ## extraHosts:
+  ##   - name: tomcat.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## Example:
+  ## extraTls:
+  ## - hosts:
+  ##     - tomcat.local
+  ##   secretName: tomcat.local-tls
+  ##
+  extraTls: []
+  ## @param ingress.extraPaths Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
+  ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ##
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## Example
+  ## secrets:
+  ##   - name: tomcat.local-tls
+  ##     key: ""
+  ##     certificate: ""
+  ##
+  secrets: []
+  ## @param ingress.extraRules Additional rules to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+  ## e.g:
+  ## extraRules:
+  ## - host: tomcat.local
+  ##     http:
+  ##       path: /
+  ##       backend:
+  ##         service:
+  ##           name: tomcat-svc
+  ##           port:
+  ##             name: http
+  ##
+  extraRules: []
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.path Ingress path
+  ##
+  path: /
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+
+## @section Volume Permissions parameters
+##
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes volume permissions in the data directory
+  ##
+  enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 11-debian-11-r36
+    digest: ""
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container' resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource  limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource  requests
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    ##
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    ##
+    requests: {}
+
+## @section Metrics parameters
+
+## Prometheus Exporters / Metrics
+##
+metrics:
+  ## Prometheus JMX Exporter: exposes the majority of tomcat jvm metrics
+  ##
+  jmx:
+    ## @param metrics.jmx.enabled Whether or not to expose JMX metrics to Prometheus
+    ##
+    enabled: false
+    ## @param metrics.jmx.catalinaOpts custom option used to enabled JMX on tomcat jvm evaluated as template
+    ##
+    catalinaOpts: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true
+    ## Bitnami JMX exporter image
+    ## ref: https://hub.docker.com/r/bitnami/jmx-exporter/tags/
+    ## @param metrics.jmx.image.registry JMX exporter image registry
+    ## @param metrics.jmx.image.repository JMX exporter image repository
+    ## @param metrics.jmx.image.tag JMX exporter image tag (immutable tags are recommended)
+    ## @param metrics.jmx.image.digest JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+    ## @param metrics.jmx.image.pullPolicy JMX exporter image pull policy
+    ## @param metrics.jmx.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/jmx-exporter
+      tag: 0.17.1-debian-11-r2
+      digest: ""
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    ## @param metrics.jmx.config [string] Configuration file for JMX exporter
+    ## Specify content for jmx-tomcat-prometheus.yml. Evaluated as a template
+    ##
+    config: |
+      jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
+      startDelaySecs: 120
+      ssl: false
+      lowercaseOutputName: true
+      lowercaseOutputLabelNames: true
+      attrNameSnakeCase: true
+    ## Prometheus JMX exporter containers' Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param metrics.jmx.containerSecurityContext.enabled Enable Prometheus JMX exporter containers' Security Context
+    ## @param metrics.jmx.containerSecurityContext.runAsUser Set Prometheus JMX exporter containers' Security Context runAsUser
+    ## @param metrics.jmx.containerSecurityContext.runAsNonRoot Set Prometheus JMX exporter containers' Security Context runAsNonRoot
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1001
+      runAsNonRoot: true
+    ## Prometheus JMX Exporter' resource requests and limits
+    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param metrics.jmx.resources.limits JMX Exporter container resource limits
+    ## @param metrics.jmx.resources.requests JMX Exporter container resource requests
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      requests: {}
+    ## @param metrics.jmx.ports.metrics JMX Exporter container metrics ports
+    ##
+    ports:
+      metrics: 5556
+    ## @param metrics.jmx.existingConfigmap Name of existing ConfigMap with JMX exporter configuration
+    ## NOTE: This will override metrics.jmx.config
+    ##
+    existingConfigmap: ""
+  ## Prometheus pod Monitor
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#podmonitorspec
+  ##
+  podMonitor:
+    ## @param metrics.podMonitor.podTargetLabels Used to keep given pod's labels in target
+    ## e.g:
+    ## - app.kubernetes.io/name
+    ##
+    podTargetLabels: []
+    ## @param metrics.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.podMonitor.namespace Optional namespace in which Prometheus is running
+    ##
+    namespace: ""
+    ## @param metrics.podMonitor.interval Specify the interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## @param metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ##
+    scrapeTimeout: 30s
+    ## @param metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: {}
+    ## @param metrics.podMonitor.scheme Scheme to use for scraping
+    ##
+    scheme: http
+    ## @param metrics.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    ## e.g:
+    ## tlsConfig:
+    ##   ca:
+    ##     secret:
+    ##       name: existingSecretName
+    ##
+    tlsConfig: {}
+    ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
+    ##
+    relabelings: []
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  ##
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled Set this to true to create prometheusRules for Prometheus operator
+    ##
+    enabled: false
+    ## @param metrics.prometheusRule.additionalLabels Additional labels that can be used so prometheusRules will be discovered by Prometheus
+    ##
+    additionalLabels: {}
+    ## @param metrics.prometheusRule.namespace namespace where prometheusRules resource should be created
+    ##
+    namespace: ""
+    ## @param metrics.prometheusRule.rules Create specified [Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+    ## Make sure to constraint the rules to the current tomcat service.
+    ## rules:
+    ##   - alert: HugeReplicationLag
+    ##     expr: up{service="{{ template "common.names.fullname" . }}-metrics"} < 1
+    ##     for: 1m
+    ##     labels:
+    ##       severity: critical
+    ##     annotations:
+    ##       description: Service {{ template "common.names.fullname" . }} Tomcat is down since 1m.
+    ##       summary: Tomcat instance is down.
+    ##
+    rules: []

--- a/agrold-javaweb/charts/virtuoso/Chart.yaml
+++ b/agrold-javaweb/charts/virtuoso/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: virtuoso
+description: > 
+  A Helm chart to deploy a Virtuoso instance with a SPARQL endpoint
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "7.2.11"
+
+icon: https://store-images.s-microsoft.com/image/apps.27150.557b4e93-c573-4bac-97ec-a7edc7a03135.f218a1cc-095b-4626-b120-86e757fd27c2.84200834-db12-40c5-b2b6-fd52ac58201a

--- a/agrold-javaweb/charts/virtuoso/README.md
+++ b/agrold-javaweb/charts/virtuoso/README.md
@@ -1,0 +1,39 @@
+# Virtuoso Helm Chart
+
+| Variable Name                                | Description                                                                                 | Default Value                                     |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `replicaCount`                               | Number of replicas for the deployment                                                       | 1                                                 |
+| `image.repository`                           | Docker image repository                                                                     | openlink/virtuoso-opensource-7                    |
+| `image.pullPolicy`                           | Pull policy for the image                                                                   | IfNotPresent                                      |
+| `image.tag`                                  | Tag of the Docker image                                                                     | "7.2.11"                                          |
+| `imagePullSecrets `                          | List of secrets to pull the Docker image from private repositories                          | []                                                |
+| `nameOverride`                               | Override for the chart name                                                                 | ""                                                |
+| `fullnameOverride`                           | Override for the full name of the chart                                                     | ""                                                |
+| `podAnnotations`                             | Annotations for the pod                                                                     | {}                                                |
+| `podSecurityContext`                         | Security context for the pod                                                                | {}                                                |
+| `securityContext`                            | Security context for the container                                                          | {}                                                |
+| `service.type`                               | Type of Kubernetes service                                                                  | ClusterIP                                         |
+| `service.port`                               | Port number for the service                                                                 | 80                                                |
+| `ingress.enabled`                            | Enable Ingress resource                                                                     | true                                              |
+| `ingress.className`                          | Class name for Ingress                                                                      | ""                                                |
+| `ingress.annotations`                        | Annotations for Ingress resource                                                            | {}                                                |
+| `ingress.hosts`                              | List of hosts for Ingress resource                                                          | virtuoso.local                                    |
+| `resources`                                  | Resource limits and requests                                                                | {}                                                |
+| `autoscaling.enabled`                        | Enable Horizontal Pod Autoscaler                                                            | false                                             |
+| `autoscaling.minReplicas`                    | Minimum number of replicas when autoscaling is enabled                                      | 1                                                 |
+| `autoscaling.maxReplicas`                    | Maximum number of replicas when autoscaling is enabled                                      | 100                                               |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage when autoscaling is enabled                               | 80                                                |
+| `nodeSelector`                               | Node labels for pod assignment                                                              | {}                                                |
+| `tolerations`                                | Tolerations for pod assignment                                                              | []                                                |
+| `affinity`                                   | Affinity settings for pod assignment                                                        | {}                                                |
+| `DAVPassword`                                | Password for DAV (WebDAV) access                                                            | "password"                                        |
+| `DBAPassword`                                | Password for DBA (Database Admin) access                                                    | "password"                                        |
+| `serveConductor`                             | Flag to enable serving the conductor                                                        | false                                             |
+| `env`                                        | Environment variables                                                                       | `IMPORT_THREAD: 2`                                |
+| `initdb.enabled`                             | Enable initialization job                                                                   | true                                              |
+| `initdb.name`                                | Name of the initialization job                                                              | sparql-initdb                                     |
+| `initdb.kind`                                | Kind of Kubernetes resource used for initialization job                                     | ConfigMap                                         |
+| `initdb.data`                                | Files inside of /initdb.d. Sonsists of map with filenames as a key and its content as a key | `"init.sh": "#!/bin/bash\necho \"Ready to go!\""` |
+| `persistence.enabled`                        | Enable persistence storage                                                                  | true                                              |
+| `persistence.name`                           | Name of the persistence storage                                                             | triplestore                                       |
+| `persistence.size`                           | Size of the persistence storage                                                             | 4Gi                                               |

--- a/agrold-javaweb/charts/virtuoso/templates/NOTES.txt
+++ b/agrold-javaweb/charts/virtuoso/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sparql.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "sparql.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sparql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "sparql.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/_helpers.tpl
+++ b/agrold-javaweb/charts/virtuoso/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sparql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sparql.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sparql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sparql.labels" -}}
+helm.sh/chart: {{ include "sparql.chart" . }}
+{{ include "sparql.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sparql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sparql.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/disableconductor.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/disableconductor.yaml
@@ -1,0 +1,205 @@
+{{- if not .Values.serveConductor }}
+apiVersion: v1
+kind: {{ .Values.initdb.kind }}
+metadata:
+  name: {{ include "sparql.fullname" . }}-disableconductor
+data:
+  "disable_conductor.sh": |
+    #!/bin/bash
+    
+    set -e
+
+    version="$(isql -U dba -P ${DBA_PASSWORD} 'EXEC=vad_list_packages();' | grep conductor | grep -oh -E '[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}')"
+    isql -U dba -P ${DBA_PASSWORD} "EXEC=vad_uninstall('conductor/$version');"
+
+    echo -e "\e[32mSucessfully disabled conductor!\e[0m"
+    tail -f /dev/null
+
+
+
+
+  "wait-for-it.sh": |
+    #!/usr/bin/env bash
+    # Use this script to test if a given TCP host/port are available
+    #https://github.com/vishnubob/wait-for-it/blob/master/wait-for-it.sh
+
+    WAITFORIT_cmdname=${0##*/}
+
+    echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+    usage()
+    {
+        cat << USAGE >&2
+    Usage:
+        $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+        -h HOST | --host=HOST       Host or IP under test
+        -p PORT | --port=PORT       TCP port under test
+                                    Alternatively, you specify the host and port as host:port
+        -s | --strict               Only execute subcommand if the test succeeds
+        -q | --quiet                Don't output any status messages
+        -t TIMEOUT | --timeout=TIMEOUT
+                                    Timeout in seconds, zero for no timeout
+        -- COMMAND ARGS             Execute command with args after the test finishes
+    USAGE
+        exit 1
+    }
+
+    wait_for()
+    {
+        if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+            echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+        else
+            echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+        fi
+        WAITFORIT_start_ts=$(date +%s)
+        while :
+        do
+            if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+                nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+                WAITFORIT_result=$?
+            else
+                (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+                WAITFORIT_result=$?
+            fi
+            if [[ $WAITFORIT_result -eq 0 ]]; then
+                WAITFORIT_end_ts=$(date +%s)
+                echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+                break
+            fi
+            sleep 1
+        done
+        return $WAITFORIT_result
+    }
+
+    wait_for_wrapper()
+    {
+        # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+        if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+            timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        else
+            timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+        fi
+        WAITFORIT_PID=$!
+        trap "kill -INT -$WAITFORIT_PID" INT
+        wait $WAITFORIT_PID
+        WAITFORIT_RESULT=$?
+        if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+            echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+        fi
+        return $WAITFORIT_RESULT
+    }
+
+    # process arguments
+    while [[ $# -gt 0 ]]
+    do
+        case "$1" in
+            *:* )
+            WAITFORIT_hostport=(${1//:/ })
+            WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+            WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+            shift 1
+            ;;
+            --child)
+            WAITFORIT_CHILD=1
+            shift 1
+            ;;
+            -q | --quiet)
+            WAITFORIT_QUIET=1
+            shift 1
+            ;;
+            -s | --strict)
+            WAITFORIT_STRICT=1
+            shift 1
+            ;;
+            -h)
+            WAITFORIT_HOST="$2"
+            if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+            shift 2
+            ;;
+            --host=*)
+            WAITFORIT_HOST="${1#*=}"
+            shift 1
+            ;;
+            -p)
+            WAITFORIT_PORT="$2"
+            if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+            shift 2
+            ;;
+            --port=*)
+            WAITFORIT_PORT="${1#*=}"
+            shift 1
+            ;;
+            -t)
+            WAITFORIT_TIMEOUT="$2"
+            if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+            shift 2
+            ;;
+            --timeout=*)
+            WAITFORIT_TIMEOUT="${1#*=}"
+            shift 1
+            ;;
+            --)
+            shift
+            WAITFORIT_CLI=("$@")
+            break
+            ;;
+            --help)
+            usage
+            ;;
+            *)
+            echoerr "Unknown argument: $1"
+            usage
+            ;;
+        esac
+    done
+
+    if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+        echoerr "Error: you need to provide a host and port to test."
+        usage
+    fi
+
+    WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+    WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+    WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+    WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+    # Check to see if timeout is from busybox?
+    WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+    WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+    WAITFORIT_BUSYTIMEFLAG=""
+    if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        # Check if busybox timeout uses -t flag
+        # (recent Alpine versions don't support -t anymore)
+        if timeout &>/dev/stdout | grep -q -e '-t '; then
+            WAITFORIT_BUSYTIMEFLAG="-t"
+        fi
+    else
+        WAITFORIT_ISBUSY=0
+    fi
+
+    if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+        wait_for
+        WAITFORIT_RESULT=$?
+        exit $WAITFORIT_RESULT
+    else
+        if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+            wait_for_wrapper
+            WAITFORIT_RESULT=$?
+        else
+            wait_for
+            WAITFORIT_RESULT=$?
+        fi
+    fi
+
+    if [[ $WAITFORIT_CLI != "" ]]; then
+        if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+            echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+            exit $WAITFORIT_RESULT
+        fi
+        exec "${WAITFORIT_CLI[@]}"
+    else
+        exit $WAITFORIT_RESULT
+    fi
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/hpa.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sparql.fullname" . }}
+  labels:
+    {{- include "sparql.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "sparql.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/ingress.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sparql.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "sparql.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/initdb.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/initdb.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.initdb.enabled }}
+apiVersion: v1
+kind: {{ .Values.initdb.kind }}
+metadata:
+  name: configmap-{{ .Values.initdb.name }}
+data:
+  {{- range $key, $val := .Values.initdb.data }}
+  {{ $key | quote }}: {{ $val  | quote }}
+  {{- end }}
+{{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/secrets.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/secrets.yaml
@@ -1,0 +1,10 @@
+{{- $fullName := include "sparql.fullname" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secrets-{{ $fullName }}
+type: Opaque
+data:
+  DAVPassword: {{ .Values.DAVPassword | b64enc | quote }}
+  DBAPassword: {{ .Values.DBAPassword | b64enc | quote }}
+

--- a/agrold-javaweb/charts/virtuoso/templates/service.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sparql.fullname" . }}
+  labels:
+    {{- include "sparql.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sparql.selectorLabels" . | nindent 4 }}

--- a/agrold-javaweb/charts/virtuoso/templates/statefulset.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/statefulset.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sparql.fullname" . }}
+  labels:
+    {{- include "sparql.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  serviceName: {{ include "sparql.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "sparql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sparql.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.initdb.enabled }}
+        - name: configmap-{{ .Values.initdb.name }}
+          configMap:
+            name: configmap-{{ .Values.initdb.name }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8890
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: '/sparql?query=select+("pong"+as+%3Fpong)+{}'
+              port: http
+          volumeMounts:
+            {{- if .Values.initdb.enabled }}
+            - name: configmap-{{ .Values.initdb.name }}
+              mountPath: /initdb.d
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: {{ .Values.persistence.name }}-pvc
+              mountPath: /database
+            {{- end }}
+          env:
+            - name: "DAV_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: secrets-{{ include "sparql.fullname" . }}
+                  key: DAVPassword
+            - name: "DBA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: secrets-{{ include "sparql.fullname" . }}
+                  key: DBAPassword
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: '/sparql?query=select+("pong"+as+%3Fpong)+{}'
+              port: http
+          startupProbe:
+            httpGet:
+              path: '/sparql?query=select+("pong"+as+%3Fpong)+{}'
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    {{- if .Values.persistence.enabled }}
+    - metadata:
+        name: {{ .Values.persistence.name }}-pvc
+      spec:
+        accessModes: [ "ReadWriteOnce" ] # This might be changed when doing clusters
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | default "4Gi"  }}
+    {{- end }}

--- a/agrold-javaweb/charts/virtuoso/templates/statefulset.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/statefulset.yaml
@@ -31,15 +31,49 @@ spec:
         {{- if .Values.initdb.enabled }}
         - name: configmap-{{ .Values.initdb.name }}
           configMap:
+            defaultMode: 0551
             name: configmap-{{ .Values.initdb.name }}
         {{- end }}
+        {{- if not .Values.serveConductor }}
+        - name: disableconductor
+          configMap:
+            defaultMode: 0551
+            name: {{ include "sparql.fullname" . }}-disableconductor
+        {{- end }}
       containers:
+        {{- if not .Values.serveConductor }}
+        # Turns out we cannot do this in the /initdb.d because 
+        # it blocks connections to the 1111 port
+        - name: disable-conductor
+          image: openlink/virtuoso-opensource-7
+          tag: 7.2.11
+          volumeMounts:
+            - name: disableconductor
+              mountPath: /mnt
+          command: 
+            - /bin/sh
+            - "-c"
+            - /mnt/..data/wait-for-it.sh localhost:1111 -t 0 -- /mnt/..data/disable_conductor.sh
+          env:
+            - name: "DBA_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: secrets-{{ include "sparql.fullname" . }}
+                  key: DBAPassword
+          
+        {{- end }}
+
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+          {{- if not .Values.serveConductor }}
+            - name: isql
+              containerPort: 1111
+              protocol: TCP
+          {{- end }}
             - name: http
               containerPort: 8890
               protocol: TCP

--- a/agrold-javaweb/charts/virtuoso/templates/tests/test-connection.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sparql.fullname" . }}-test-connection"
+  labels:
+    {{- include "sparql.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "sparql.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/agrold-javaweb/charts/virtuoso/values.yaml
+++ b/agrold-javaweb/charts/virtuoso/values.yaml
@@ -1,0 +1,100 @@
+# Default values for sparql.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: openlink/virtuoso-opensource-7
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "7.2.11"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: sparql.127.0.0.1.sslip.io
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+DAVPassword: "password"
+DBAPassword: "password"
+
+env:
+  # ENABLE_TRACE: "yes"
+  IMPORT_THREAD: 2
+
+# Check this https://docs.openlinksw.com/virtuoso/rdfapi/#rdfapidataimportloadrdfuri
+initdb:
+  enabled: false
+  name: sparql-initdb
+  kind: ConfigMap
+  data:
+    init.sh: |
+      #!/bin/bash
+      set -e
+      echo "Data loaded"
+
+persistence:
+  enabled: true
+  name: triplestore
+  size: 4Gi

--- a/agrold-javaweb/charts/virtuoso/values.yaml
+++ b/agrold-javaweb/charts/virtuoso/values.yaml
@@ -41,7 +41,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: sparql.127.0.0.1.sslip.io
+    - host: virtuoso.local
       paths:
         - path: /
           pathType: ImplementationSpecific
@@ -78,6 +78,7 @@ affinity: {}
 
 DAVPassword: "password"
 DBAPassword: "password"
+serveConductor: false
 
 env:
   # ENABLE_TRACE: "yes"
@@ -85,14 +86,13 @@ env:
 
 # Check this https://docs.openlinksw.com/virtuoso/rdfapi/#rdfapidataimportloadrdfuri
 initdb:
-  enabled: false
+  enabled: true
   name: sparql-initdb
   kind: ConfigMap
   data:
     init.sh: |
       #!/bin/bash
-      set -e
-      echo "Data loaded"
+      echo "Ready to go!"
 
 persistence:
   enabled: true

--- a/agrold-javaweb/nb-configuration.xml
+++ b/agrold-javaweb/nb-configuration.xml
@@ -6,6 +6,7 @@ The configuration is intended to be shared among all the users of project and
 therefore it is assumed to be part of version control checkout.
 Without this configuration present, some functionality in the IDE may be limited or fail altogether.
 -->
+    <libraries xmlns="http://www.netbeans.org/ns/cdnjs-libraries/1"/>
     <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
         <!--
 Properties that influence various parts of the IDE, especially code formatting and the like. 
@@ -14,6 +15,13 @@ That way multiple projects can share the same settings (useful for formatting ru
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
         <org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>ide</org-netbeans-modules-maven-jaxws.rest_2e_config_2e_type>
-        <org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>Tomcat</org-netbeans-modules-maven-j2ee.netbeans_2e_hint_2e_deploy_2e_server>
+        <org-netbeans-modules-css-prep.less_2e_mappings>/less:/css</org-netbeans-modules-css-prep.less_2e_mappings>
+        <org-netbeans-modules-css-prep.less_2e_enabled>false</org-netbeans-modules-css-prep.less_2e_enabled>
+        <org-netbeans-modules-css-prep.sass_2e_enabled>false</org-netbeans-modules-css-prep.sass_2e_enabled>
+        <org-netbeans-modules-css-prep.sass_2e_compiler_2e_options/>
+        <org-netbeans-modules-css-prep.less_2e_compiler_2e_options/>
+        <org-netbeans-modules-css-prep.sass_2e_mappings>/scss:/css</org-netbeans-modules-css-prep.sass_2e_mappings>
+        <org-netbeans-modules-web-clientproject-api.js_2e_libs_2e_folder>js/libs</org-netbeans-modules-web-clientproject-api.js_2e_libs_2e_folder>
+        <org-netbeans-modules-javascript2-requirejs.enabled>true</org-netbeans-modules-javascript2-requirejs.enabled>
     </properties>
 </project-shared-configuration>

--- a/agrold-javaweb/nbactions.template.xml
+++ b/agrold-javaweb/nbactions.template.xml
@@ -9,6 +9,7 @@
             </packagings>
             <goals>
                 <goal>package</goal>
+                <goal>docker:build</goal>
                 <goal>docker:start</goal>
                 <goal>docker:watch</goal>
             </goals>

--- a/agrold-javaweb/nbactions.template.xml
+++ b/agrold-javaweb/nbactions.template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>run</actionName>
+            <packagings>
+                <packaging>war</packaging>
+                <packaging>ear</packaging>
+                <packaging>ejb</packaging>
+            </packagings>
+            <goals>
+                <goal>package</goal>
+                <goal>docker:start</goal>
+                <goal>docker:watch</goal>
+            </goals>
+        </action>
+        
+        
+    </actions>

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -12,6 +12,7 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <agrold.name>aldp</agrold.name>
+        <CATALINA_OPTS></CATALINA_OPTS>
     </properties>
 
     <name>agrold-javaweb-${agrold.name}</name>
@@ -175,6 +176,34 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.43.4</version>
+                <configuration>
+                    <keepContainer>false</keepContainer>
+                    <images>
+                        <image>
+                            <name>ghcr.io/southgreenplatform/agrold</name>
+                            <build>
+                                <contextDir>${project.basedir}</contextDir>
+                                <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>8080:8080</port>
+                                </ports>
+                                <env>
+                                    <TOMCAT_ALLOW_REMOTE_MANAGEMENT>yes</TOMCAT_ALLOW_REMOTE_MANAGEMENT>
+                                    <TOMCAT_USERNAME>manager</TOMCAT_USERNAME>
+                                    <TOMCAT_PASSWORD>password</TOMCAT_PASSWORD>
+                                    <CATALINA_OPTS>${CATALINA_OPTS}</CATALINA_OPTS>
+                                </env>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
             </plugin>
         </plugins>
         <finalName>${agrold.name}</finalName>

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -3,17 +3,19 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>agrold</groupId>
-    <artifactId>${env.AGROLD_NAME}</artifactId>
+    <artifactId>agrold</artifactId>
     <version>1.0</version>
     <packaging>war</packaging>
 
-    <name>agrold-javaweb-${env.AGROLD_NAME}</name>
 
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <agrold.name>aldp</agrold.name>
     </properties>
-    
+
+    <name>agrold-javaweb-${agrold.name}</name>
+
     <repositories>
         <!--repository>
             <id>maven2-repository.java.net</id>
@@ -175,7 +177,7 @@
                 </executions>
             </plugin>
         </plugins>
-        <finalName>${project.artifactId}</finalName>
+        <finalName>${agrold.name}</finalName>
     </build>
 
 </project>

--- a/agrold-javaweb/src/main/java/agrold/ogust/config/MySQLProperties.java
+++ b/agrold-javaweb/src/main/java/agrold/ogust/config/MySQLProperties.java
@@ -43,9 +43,9 @@ public class MySQLProperties {
             String usr = System.getProperty("agrold.db_username");
             String pwd = System.getProperty("agrold.db_password");
 
-            if (URL == null) throw new NullPointerException("Missing env Variable: AGROLD_DB_CONNECTION_URL");
-            if (usr == null) throw new NullPointerException("Missing env Variable: AGROLD_DB_USERNAME");
-            if (pwd == null) throw new NullPointerException("Missing env Variable: AGROLD_DB_PASSWORD");
+            if (URL == null) throw new NullPointerException("Missing system property: agrold.db_connection_url");
+            if (usr == null) throw new NullPointerException("Missing system property: agrold.db_username");
+            if (pwd == null) throw new NullPointerException("Missing system property: agrold.db_password");
 
             lines.add(URL);
             lines.add(usr);

--- a/agrold-javaweb/src/main/java/agrold/webservices/dao/CustomizableServicesManager.java
+++ b/agrold-javaweb/src/main/java/agrold/webservices/dao/CustomizableServicesManager.java
@@ -39,10 +39,13 @@ public class CustomizableServicesManager {
             // add a new tag
             JSONObject tagObj = new JSONObject();
 
+            // Host only has hostname and port, meaning no protocol
+            String strippedUrl = System.getProperty("agrold.baseurl", "localhost:8080").replaceAll("http://", "").replaceAll("https://", "");
+
             // here we will fill the host property defined by the system property agrold.baseurl and agrold.name
-            jsonObj.put("host", 
-                System.getProperty("agrold.baseurl", "http://localhost:8080/") + System.getProperty("agrold.name", "aldp")
-            );
+            jsonObj.put("host", strippedUrl);
+
+            jsonObj.put("basePath", "/" + System.getProperty("agrold.name", "aldp") + "/api");
             
             reader.close();
         } catch (FileNotFoundException e) {

--- a/agrold-javaweb/src/main/webapp/config/agrold-api.json
+++ b/agrold-javaweb/src/main/webapp/config/agrold-api.json
@@ -1,5 +1,5 @@
 {
-    "basePath": "/api",
+    "basePath": "/aldp/api",
     "paths": {
         "/delete-service": {
             "delete": {
@@ -1461,7 +1461,7 @@
             }
         }
     },
-    "host": "http://agrold.southgreen.fr/aldp/", 
+    "host": "agrold.southgreen.fr", 
     "schemes": ["http"],
     "externalDocs": {
         "description": "Find out more about Swagger",

--- a/agrold-javaweb/src/main/webapp/includes.jsp
+++ b/agrold-javaweb/src/main/webapp/includes.jsp
@@ -37,7 +37,7 @@
     }
 
     const system_context = parseJsp('<%= System.getProperty("agrold.name", "aldp") %>')
-    const system_baseurl = parseJsp('<%= System.getProperty("agrold.baseurl", "aldp") %>')
+    const system_baseurl = parseJsp('<%= System.getProperty("agrold.baseurl", "http://localhost:8080") %>')
     const system_sparqlendpoint = parseJsp('<%= System.getProperty("agrold.sparql_endpoint", "http://sparql.southgreen.fr") %>')
 </script>
 <script type="text/javascript" src="config/config.js"></script>

--- a/agrold-javaweb/src/main/webapp/relfinder.jsp
+++ b/agrold-javaweb/src/main/webapp/relfinder.jsp
@@ -29,16 +29,28 @@
         <title>AgroLD: Find Relationships</title>
         <!-- Les includes -->
         <jsp:include page="includes.jsp"></jsp:include>
-        </head>
-        <body>        
+        <style>
+            iframe {
+                height: 100%;
+                width: 100%;
+                position: absolute;
+                left: 0;
+                top: 0;
+                border-style: none;
+            }
+        </style>
+    </head>
+    <body>        
         <jsp:include page="header.jsp"></jsp:include>
+            <%! String rfLink = System.getProperty("agrold.rf_link", "http://rf.southgreen.fr/"); %>
             <div class="container-fluid arian-thread">
                 <div class="info_title">
-                    <div class="container pos-l">Search > <span class="active-p">Explore relationship</span></div>
+                    <div class="container pos-l">Search > <span class="active-p">Explore relationship</span> <a target="_blank" href="<%= rfLink %>"><em>(Open Relfinder Reformed in new tab)</em></a></div>
                 </div>
             </div>
+            
             <div class="foowrap">
-                <section>
+                <!-- <section>
                     <OBJECT CLASSID="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%" 
                             CODEBASE="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,040,0" >
                         <PARAM name="movie" VALUE="RelFinder.swf">
@@ -48,7 +60,17 @@
                                PLUGINSPAGE="http://www.macromedia.com/go/getflashplayer" width="100%" height="700px" >
                         </EMBED>            
                     </OBJECT>    
-                </section>
+                </section> -->
+                <iframe 
+                    src="<%= rfLink %>"
+                    sandbox="allow-downloads-without-user-activation allow-downloads allow-forms allow-same-origin allow-scripts" 
+                    allowfullscreen="true" 
+                    title="RelFinder Reformed"
+                    name="relfinderreformed"
+                >
+
+                </iframe>
+
             </div>
         <jsp:include page="footer.html"></jsp:include>
     </body>


### PR DESCRIPTION
I guess this is time to pass on the v2 and integrate our changes :)

legacy Agrold will be available on, `http://agrold.southgreen.fr/agrold` and will be slowly migrated to `http://v2.agrold.org/`, the first domain will be changed when the switch will be completed

## Related PRs

**Deployment:**
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/62
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/64

**refactors:**
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/59
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/55

**CICD:**
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/61
- https://github.com/SouthGreenPlatform/AgroLD_webapp/pull/60
