### PR TITLE
feat: bump to 2.1.0

### DIFF
--- a/.github/actions/chart-releaser-action/action.yaml
+++ b/.github/actions/chart-releaser-action/action.yaml
@@ -1,0 +1,96 @@
+name: "Helm Chart Releaser"
+description: "Host a Helm charts repo on GitHub Pages"
+author: "The Helm authors"
+branding:
+  color: blue
+  icon: anchor
+inputs:
+  version:
+    description: "The chart-releaser version to use (default: v1.6.0)"
+    required: false
+    default: v1.6.0
+  config:
+    description: "The relative path to the chart-releaser config file"
+    required: false
+  charts_dir:
+    description: The charts directory
+    required: false
+    default: charts
+  install_dir:
+    description: "Where to install the cr tool"
+    required: false
+  install_only:
+    description: "Just install cr tool"
+    required: false
+  skip_packaging:
+    description: "Skip the packaging option (do your custom packaging before running this action)"
+    required: false
+  skip_existing:
+    description: "Skip package upload if release exists"
+    required: false
+  mark_as_latest:
+    description: Mark the created GitHub release as 'latest'
+    required: false
+    default: true
+outputs:
+  changed_charts:
+    description: "A comma-separated list of charts that were released on this run. Will be an empty string if no updates were detected, will be unset if `--skip_packaging` is used: in the latter case your custom packaging step is responsible for setting its own outputs if you need them."
+    value: ${{ steps.release.outputs.changed_charts }}
+  chart_version:
+    description: "The version of the most recently generated charts; will be set even if no charts have been updated since the last run."
+    value: ${{ steps.release.outputs.chart_version }}
+
+runs:
+  using: composite
+  steps:
+    - id: release
+      run: |
+        owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
+        repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
+
+        args=(--owner "$owner" --repo "$repo")
+        args+=(--charts-dir "${{ inputs.charts_dir }}")
+
+        if [[ -n "${{ inputs.version }}" ]]; then
+            args+=(--version "${{ inputs.version }}")
+        fi
+
+        if [[ -n "${{ inputs.config }}" ]]; then
+            args+=(--config "${{ inputs.config }}")
+        fi
+
+        if [[ -z "${{ inputs.install_dir }}" ]]; then
+          install="$RUNNER_TOOL_CACHE/cr/${{ inputs.version }}/$(uname -m)"
+          echo "$install" >> "$GITHUB_PATH"
+          args+=(--install-dir "$install")
+        else
+          echo ${{ inputs.install_dir }} >> "$GITHUB_PATH"
+          args+=(--install-dir "${{ inputs.install_dir }}")
+        fi
+
+        if [[ -n "${{ inputs.install_only }}" ]]; then
+            args+=(--install-only "${{ inputs.install_only }}")
+        fi
+
+        if [[ -n "${{ inputs.skip_packaging }}" ]]; then
+            args+=(--skip-packaging "${{ inputs.skip_packaging }}")
+        fi
+
+        if [[ -n "${{ inputs.skip_existing }}" ]]; then
+            args+=(--skip-existing "${{ inputs.skip_existing }}")
+        fi
+
+        if [[ -n "${{ inputs.mark_as_latest }}" ]]; then
+            args+=(--mark-as-latest "${{ inputs.mark_as_latest }}")
+        fi
+
+        "$GITHUB_ACTION_PATH/cr.sh" "${args[@]}"
+
+        if [[ -f changed_charts.txt ]]; then
+            cat changed_charts.txt >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f chart_version.txt ]]; then
+            cat chart_version.txt >> "$GITHUB_OUTPUT"
+        fi
+        rm -f changed_charts.txt chart_version.txt
+      shell: bash

--- a/.github/actions/chart-releaser-action/cr.sh
+++ b/.github/actions/chart-releaser-action/cr.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DEFAULT_CHART_RELEASER_VERSION=v1.6.0
+
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") <options>
+
+    -h, --help               Display help
+    -v, --version            The chart-releaser version to use (default: $DEFAULT_CHART_RELEASER_VERSION)"
+        --config             The path to the chart-releaser config file
+    -d, --charts-dir         The charts directory (default: charts)
+    -o, --owner              The repo owner
+    -r, --repo               The repo name
+    -n, --install-dir        The Path to install the cr tool
+    -i, --install-only       Just install the cr tool
+    -s, --skip-packaging     Skip the packaging step (run your own packaging before using the releaser)
+        --skip-existing      Skip package upload if release exists
+    -l, --mark-as-latest     Mark the created GitHub release as 'latest' (default: true)
+EOF
+}
+
+main() {
+  local version="$DEFAULT_CHART_RELEASER_VERSION"
+  local config=
+  local charts_dir=charts
+  local owner=
+  local repo=
+  local install_dir=
+  local install_only=
+  local skip_packaging=
+  local skip_existing=
+  local mark_as_latest=true
+
+  parse_command_line "$@"
+
+  : "${CR_TOKEN:?Environment variable CR_TOKEN must be set}"
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel)
+  pushd "$repo_root" >/dev/null
+
+  if [[ -z "$skip_packaging" ]]; then
+    echo 'Looking up latest tag...'
+    local latest_tag
+    latest_tag=$(lookup_latest_tag)
+
+    echo "Discovering changed charts since '$latest_tag'..."
+    local changed_charts=()
+    readarray -t changed_charts <<<"$(lookup_changed_charts "$latest_tag")"
+
+    if [[ -n "${changed_charts[*]}" ]]; then
+      install_chart_releaser
+
+      rm -rf .cr-release-packages
+      mkdir -p .cr-release-packages
+
+      rm -rf .cr-index
+      mkdir -p .cr-index
+
+      for chart in "${changed_charts[@]}"; do
+        if [[ -d "$chart" ]]; then
+          package_chart "$chart"
+        else
+          echo "Nothing to do. No chart changes detected."
+        fi
+      done
+
+      release_charts
+      update_index
+      echo "changed_charts=$(
+        IFS=,
+        echo "${changed_charts[*]}"
+      )" >changed_charts.txt
+    else
+      echo "Nothing to do. No chart changes detected."
+      echo "changed_charts=" >changed_charts.txt
+    fi
+  else
+    install_chart_releaser
+    rm -rf .cr-index
+    mkdir -p .cr-index
+    release_charts
+    update_index
+  fi
+
+  echo "chart_version=${latest_tag}" >chart_version.txt
+
+  popd >/dev/null
+}
+
+parse_command_line() {
+  while :; do
+    case "${1:-}" in
+    -h | --help)
+      show_help
+      exit
+      ;;
+    --config)
+      if [[ -n "${2:-}" ]]; then
+        config="$2"
+        shift
+      else
+        echo "ERROR: '--config' cannot be empty." >&2
+        show_help
+        exit 1
+      fi
+      ;;
+    -v | --version)
+      if [[ -n "${2:-}" ]]; then
+        version="$2"
+        shift
+      else
+        echo "ERROR: '-v|--version' cannot be empty." >&2
+        show_help
+        exit 1
+      fi
+      ;;
+    -d | --charts-dir)
+      if [[ -n "${2:-}" ]]; then
+        charts_dir="$2"
+        shift
+      else
+        echo "ERROR: '-d|--charts-dir' cannot be empty." >&2
+        show_help
+        exit 1
+      fi
+      ;;
+    -o | --owner)
+      if [[ -n "${2:-}" ]]; then
+        owner="$2"
+        shift
+      else
+        echo "ERROR: '--owner' cannot be empty." >&2
+        show_help
+        exit 1
+      fi
+      ;;
+    -r | --repo)
+      if [[ -n "${2:-}" ]]; then
+        repo="$2"
+        shift
+      else
+        echo "ERROR: '--repo' cannot be empty." >&2
+        show_help
+        exit 1
+      fi
+      ;;
+    -n | --install-dir)
+      if [[ -n "${2:-}" ]]; then
+        install_dir="$2"
+        shift
+      fi
+      ;;
+    -i | --install-only)
+      if [[ -n "${2:-}" ]]; then
+        install_only="$2"
+        shift
+      fi
+      ;;
+    -s | --skip-packaging)
+      if [[ -n "${2:-}" ]]; then
+        skip_packaging="$2"
+        shift
+      fi
+      ;;
+    --skip-existing)
+      if [[ -n "${2:-}" ]]; then
+        skip_existing="$2"
+        shift
+      fi
+      ;;
+    -l | --mark-as-latest)
+      if [[ -n "${2:-}" ]]; then
+        mark_as_latest="$2"
+        shift
+      fi
+      ;;
+    *)
+      break
+      ;;
+    esac
+
+    shift
+  done
+
+  if [[ -z "$owner" ]]; then
+    echo "ERROR: '-o|--owner' is required." >&2
+    show_help
+    exit 1
+  fi
+
+  if [[ -z "$repo" ]]; then
+    echo "ERROR: '-r|--repo' is required." >&2
+    show_help
+    exit 1
+  fi
+
+  if [[ -z "$install_dir" ]]; then
+    local arch
+    arch=$(uname -m)
+    install_dir="$RUNNER_TOOL_CACHE/cr/$version/$arch"
+  fi
+
+  if [[ -n "$install_only" ]]; then
+    echo "Will install cr tool and not run it..."
+    install_chart_releaser
+    exit 0
+  fi
+}
+
+install_chart_releaser() {
+  if [[ ! -d "$RUNNER_TOOL_CACHE" ]]; then
+    echo "Cache directory '$RUNNER_TOOL_CACHE' does not exist" >&2
+    exit 1
+  fi
+
+  if [[ ! -d "$install_dir" ]]; then
+    mkdir -p "$install_dir"
+
+    echo "Installing chart-releaser on $install_dir..."
+    curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/$version/chart-releaser_${version#v}_linux_amd64.tar.gz"
+    tar -xzf cr.tar.gz -C "$install_dir"
+    rm -f cr.tar.gz
+  fi
+
+  echo 'Adding cr directory to PATH...'
+  export PATH="$install_dir:$PATH"
+}
+
+lookup_latest_tag() {
+  git fetch --tags >/dev/null 2>&1
+
+  if git symbolic-ref --short -q HEAD; then
+    if ! git describe --tags --abbrev=0 HEAD~ 2>/dev/null; then
+      git rev-list --max-parents=0 --first-parent HEAD
+    fi
+  else
+    # In a detached HEAD state, such as when the pipeline
+    # is triggered by a push on a tag commit, we need to look back
+    # by date
+    current_commit=$(git rev-parse HEAD)
+    for tag in $(git tag --sort=-creatordate); do
+      if [ $(git rev-parse "$tag") = "$current_commit" ]; then
+        continue
+      else
+        echo "$tag"
+        break
+      fi
+    done
+  fi
+}
+
+
+filter_charts() {
+  while read -r chart; do
+    [[ ! -d "$chart" ]] && continue
+    local file="$chart/Chart.yaml"
+    if [[ -f "$file" ]]; then
+      echo "$chart"
+    else
+      echo "WARNING: $file is missing, assuming that '$chart' is not a Helm chart. Skipping." 1>&2
+    fi
+  done
+}
+
+lookup_changed_charts() {
+  local commit="$1"
+
+  if [ -z "$commit" ]; then
+    # If no commit is given (i.e., no previous tag), consider all charts.
+    find "$charts_dir" -maxdepth 1 -type d | filter_charts
+  else
+    local changed_files
+    changed_files=$(git diff --find-renames --name-only "$commit" -- "$charts_dir")
+
+    local depth=$(($(tr "/" "\n" <<<"$charts_dir" | sed '/^\(\.\)*$/d' | wc -l) + 1))
+    local fields="1-${depth}"
+
+    cut -d '/' -f "$fields" <<<"$changed_files" | uniq | filter_charts
+  fi
+}
+
+
+package_chart() {
+  local chart="$1"
+
+  local args=("$chart" --package-path .cr-release-packages)
+  if [[ -n "$config" ]]; then
+    args+=(--config "$config")
+  fi
+
+  echo "Packaging chart '$chart'..."
+  cr package "${args[@]}"
+}
+
+release_charts() {
+  local args=(-o "$owner" -r "$repo" -c "$(git rev-parse HEAD)")
+  if [[ -n "$config" ]]; then
+    args+=(--config "$config")
+  fi
+  if [[ -n "$skip_existing" ]]; then
+    args+=(--skip-existing)
+  fi
+  if [[ "$mark_as_latest" = false ]]; then
+    args+=(--make-release-latest=false)
+  fi
+
+  echo 'Releasing charts...'
+  cr upload "${args[@]}"
+}
+
+update_index() {
+  local args=(-o "$owner" -r "$repo" --push)
+  if [[ -n "$config" ]]; then
+    args+=(--config "$config")
+  fi
+
+  echo 'Updating charts repo index...'
+  cr index "${args[@]}"
+}
+
+main "$@"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,8 +15,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
     - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.6.0
+      uses: ./.github/actions/chart-releaser-action
       env:
         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       with:

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -11,7 +11,7 @@ COPY . /build_dir
 RUN mvn clean install -Dagrold.name=${AGROLD_NAME}
 
 # Run stage
-FROM bitnami/tomcat:7
+FROM bitnami/tomcat:8.5
 
 ARG GIT_COMMIT=unknown
 ARG AGROLD_NAME=aldp

--- a/agrold-javaweb/charts/agrold-javaweb/.helmignore
+++ b/agrold-javaweb/charts/agrold-javaweb/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# img folder
+img/

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.lock
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 2.14.1
-- name: virtuoso
-  repository: file://../virtuoso
-  version: 0.1.0
-digest: sha256:c582e2a872feb8c8cb2fe1c1587f0e46b2170284be489805c86fe8c42584600f
-generated: "2024-02-09T15:18:42.633332491+01:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.19.1
+digest: sha256:c883732817d9aaa3304f7b3109262aa338959de15b432dc5a2dbde13d2e136a5
+generated: "2024-03-27T14:58:35.744336265+01:00"

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
@@ -9,7 +9,7 @@ annotations:
       image: docker.io/bitnami/tomcat:10.1.20-debian-12-r0
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 2.0.0
+appVersion: 2.1.0
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -45,4 +45,5 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
+- https://github.com/SouthGreenPlatform/AgroLD_webapp
 version: 2.0.0

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
@@ -1,21 +1,28 @@
 annotations:
   category: ApplicationServer
+  images: |
+    - name: jmx-exporter
+      image: docker.io/bitnami/jmx-exporter:0.20.0-debian-12-r12
+    - name: os-shell
+      image: docker.io/bitnami/os-shell:12-debian-12-r17
+    - name: tomcat
+      image: docker.io/bitnami/tomcat:10.1.20-debian-12-r0
+  licenses: Apache-2.0
 apiVersion: v2
 appVersion: 2.0.0
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 2.x.x
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  tags:
+  - bitnami-common
+  version: 2.x.x
 description: |
   This helm chart aims to deploy AgroLD with Tomcat. 
-  It is based on bitnami's helm chart for Tomcat, version 10.4.5
+  It is based on bitnami's helm chart for Tomcat, version 11.0.0
 
   Original description:
   Apache Tomcat is an open-source web server designed to host and run Java-based
   web applications. It is a lightweight server with a good performance for applications
-  running in production environments.
 home: https://github.com/SouthGreenPlatform/AgroLD_webapp/tree/master
 icon: https://raw.githubusercontent.com/SouthGreenPlatform/AgroLD_webapp/0513e23f842864379a635998897eb98d2d3eec6b/agrold-javaweb/src/main/webapp/images/Sans%20titre-1.png
 keywords:
@@ -29,15 +36,13 @@ keywords:
   - SPARQL
   - Semantic Web
 maintainers:
-  - name: Bitnami
-    url: https://github.com/bitnami/charts
-  - name: Yann POMIE
-    url: https://yann-pomie.fr
-  - name: Pierre LARMANDE
-    url: https://sites.google.com/site/larmandepierre
-name: agrold-javaweb
+- name: VMware, Inc.
+  url: https://github.com/bitnami/charts
+- name: Yann POMIE
+  url: https://yann-pomie.fr
+- name: Pierre LARMANDE
+  url: https://sites.google.com/site/larmandepierre
+name: tomcat
 sources:
-  - https://github.com/bitnami/containers/tree/main/bitnami/tomcat
-  - http://tomcat.apache.org
-  - https://github.com/SouthGreenPlatform/AgroLD_webapp/tree/master
-version: 1.0.0
+- https://github.com/bitnami/charts/tree/main/bitnami/tomcat
+version: 2.0.0

--- a/agrold-javaweb/charts/agrold-javaweb/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/README.md
@@ -74,6 +74,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+| `global.compatibility.openshift.adaptSecurityContext` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `disabled` |
 
 ### Common parameters
 

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/.helmignore
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/.helmignore
@@ -20,3 +20,5 @@
 .idea/
 *.tmproj
 .vscode/
+# img folder
+img/

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/Chart.yaml
@@ -1,10 +1,11 @@
 annotations:
   category: Infrastructure
+  licenses: Apache-2.0
 apiVersion: v2
-appVersion: 2.0.3
+appVersion: 2.19.1
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
-home: https://github.com/bitnami/charts/tree/master/bitnami/common
+home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
 keywords:
 - common
@@ -13,11 +14,10 @@ keywords:
 - function
 - bitnami
 maintainers:
-- name: Bitnami
+- name: VMware, Inc.
   url: https://github.com/bitnami/charts
 name: common
 sources:
 - https://github.com/bitnami/charts
-- https://www.bitnami.com/
 type: library
-version: 2.0.3
+version: 2.19.1

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/README.md
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/README.md
@@ -1,18 +1,18 @@
 # Bitnami Common Library Chart
 
-A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for grouping common logic between bitnami charts.
+A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for grouping common logic between Bitnami charts.
 
 ## TL;DR
 
 ```yaml
 dependencies:
   - name: common
-    version: 1.x.x
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
 ```
 
-```bash
-$ helm dependency update
+```console
+helm dependency update
 ```
 
 ```yaml
@@ -24,6 +24,8 @@ data:
   myvalue: "Hello World"
 ```
 
+Looking to use our applications in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the enterprise edition of Bitnami Application Catalog.
+
 ## Introduction
 
 This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
@@ -32,127 +34,10 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Parameters
-
-The following table lists the helpers available in the library which are scoped in different sections.
-
-### Affinities
-
-| Helper identifier             | Description                                          | Expected Input                                 |
-|-------------------------------|------------------------------------------------------|------------------------------------------------|
-| `common.affinities.nodes.soft` | Return a soft nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
-| `common.affinities.nodes.hard` | Return a hard nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")` |
-| `common.affinities.pods.soft`  | Return a soft podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
-| `common.affinities.pods.hard`  | Return a hard podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`           |
-
-### Capabilities
-
-| Helper identifier                              | Description                                                                                    | Expected Input    |
-|------------------------------------------------|------------------------------------------------------------------------------------------------|-------------------|
-| `common.capabilities.kubeVersion`              | Return the target Kubernetes version (using client default if .Values.kubeVersion is not set). | `.` Chart context |
-| `common.capabilities.cronjob.apiVersion`       | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context |
-| `common.capabilities.deployment.apiVersion`    | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
-| `common.capabilities.statefulset.apiVersion`   | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
-| `common.capabilities.ingress.apiVersion`       | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
-| `common.capabilities.rbac.apiVersion`          | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context |
-| `common.capabilities.crd.apiVersion`           | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
-| `common.capabilities.policy.apiVersion`        | Return the appropriate apiVersion for podsecuritypolicy.                                       | `.` Chart context |
-| `common.capabilities.networkPolicy.apiVersion` | Return the appropriate apiVersion for networkpolicy.                                           | `.` Chart context |
-| `common.capabilities.apiService.apiVersion`    | Return the appropriate apiVersion for APIService.                                              | `.` Chart context |
-| `common.capabilities.hpa.apiVersion`           | Return the appropriate apiVersion for Horizontal Pod Autoscaler                                | `.` Chart context |
-| `common.capabilities.supportsHelmVersion`      | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
-
-### Errors
-
-| Helper identifier                       | Description                                                                                                                                                            | Expected Input                                                                      |
-|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| `common.errors.upgrade.passwords.empty` | It will ensure required passwords are given when we are upgrading a chart. If `validationErrors` is not empty it will throw an error and will stop the upgrade action. | `dict "validationErrors" (list $validationError00 $validationError01)  "context" $` |
-
-### Images
-
-| Helper identifier           | Description                                          | Expected Input                                                                                          |
-|-----------------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| `common.images.image`       | Return the proper and full image name                | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageroot) for the structure. |
-| `common.images.pullSecrets` | Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead) | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global` |
-| `common.images.renderPullSecrets` | Return the proper Docker Image Registry Secret Names (evaluates values as templates) | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $` |
-
-### Ingress
-
-| Helper identifier                         | Description                                                                                                       | Expected Input                                                                                                                                                                   |
-|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version                                              | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
-| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                                                                  | `.` Chart context                                                                                                                                                                |
-| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported                                                          | `.` Chart context                                                                                                                                                                |
-| `common.ingress.certManagerRequest`       | Prints "true" if required cert-manager annotations for TLS signed certificates are set in the Ingress annotations | `dict "annotations" .Values.path.to.the.ingress.annotations`                                                                                                                     |
-
-### Labels
-
-| Helper identifier           | Description                                                                 | Expected Input    |
-|-----------------------------|-----------------------------------------------------------------------------|-------------------|
-| `common.labels.standard`    | Return Kubernetes standard labels                                           | `.` Chart context |
-| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector` | `.` Chart context |
-
-### Names
-
-| Helper identifier                 | Description                                                           | Expected Input    |
-|-----------------------------------|-----------------------------------------------------------------------|-------------------|
-| `common.names.name`               | Expand the name of the chart or use `.Values.nameOverride`            | `.` Chart context |
-| `common.names.fullname`           | Create a default fully qualified app name.                            | `.` Chart context |
-| `common.names.namespace`          | Allow the release namespace to be overridden                          | `.` Chart context |
-| `common.names.fullname.namespace` | Create a fully qualified app name adding the installation's namespace | `.` Chart context |
-| `common.names.chart`              | Chart name plus version                                               | `.` Chart context |
-
-### Secrets
-
-| Helper identifier         | Description                                                  | Expected Input                                                                                                                                                                                                                  |
-|---------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.secrets.name`     | Generate the name of the secret.                             | `dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $` see [ExistingSecret](#existingsecret) for the structure.                                                                  |
-| `common.secrets.key`      | Generate secret key.                                         | `dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName"` see [ExistingSecret](#existingsecret) for the structure.                                                                                             |
-| `common.passwords.manage` | Generate secret password or retrieve one if already created. | `dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "context" $`, length, strong and chartNAme fields are optional. |
-| `common.secrets.exists`   | Returns whether a previous generated secret already exists.  | `dict "secret" "secret-name" "context" $`                                                                                                                                                                                       |
-
-### Storage
-
-| Helper identifier             | Description                           | Expected Input                                                                                                      |
-|-------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| `common.storage.class` | Return  the proper Storage Class | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure. |
-
-### TplValues
-
-| Helper identifier         | Description                            | Expected Input                                                                                                                                           |
-|---------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.tplvalues.render` | Renders a value that contains template | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frequently is the chart context `$` or `.` |
-
-### Utils
-
-| Helper identifier              | Description                                                                              | Expected Input                                                         |
-|--------------------------------|------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| `common.utils.fieldToEnvVar`   | Build environment variable name given a field.                                           | `dict "field" "my-password"`                                           |
-| `common.utils.secret.getvalue` | Print instructions to get a secret value.                                                | `dict "secret" "secret-name" "field" "secret-value-field" "context" $` |
-| `common.utils.getValueFromKey` | Gets a value from `.Values` object given its key path                                    | `dict "key" "path.to.key" "context" $`                                 |
-| `common.utils.getKeyFromList`  | Returns first `.Values` key with a defined value or first of the list if all non-defined | `dict "keys" (list "path.to.key1" "path.to.key2") "context" $`         |
-
-### Validations
-
-| Helper identifier                                | Description                                                                                                                   | Expected Input                                                                                                                                                                                                                                                           |
-|--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.validations.values.single.empty`         | Validate a value must not be empty.                                                                                           | `dict "valueKey" "path.to.value" "secret" "secret.name" "field" "my-password" "subchart" "subchart" "context" $` secret, field and subchart are optional. In case they are given, the helper will generate a how to get instruction. See [ValidateValue](#validatevalue) |
-| `common.validations.values.multiple.empty`       | Validate a multiple values must not be empty. It returns a shared error for all the values.                                   | `dict "required" (list $validateValueConf00 $validateValueConf01) "context" $`. See [ValidateValue](#validatevalue)                                                                                                                                                      |
-| `common.validations.values.mariadb.passwords`    | This helper will ensure required password for MariaDB are not empty. It returns a shared error for all the values.            | `dict "secret" "mariadb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mariadb chart and the helper.                                                                                      |
-| `common.validations.values.mysql.passwords`      | This helper will ensure required password for MySQL are not empty. It returns a shared error for all the values.              | `dict "secret" "mysql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mysql chart and the helper.                                                                                      |
-| `common.validations.values.postgresql.passwords` | This helper will ensure required password for PostgreSQL are not empty. It returns a shared error for all the values.         | `dict "secret" "postgresql-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use postgresql chart and the helper.                                                                                |
-| `common.validations.values.redis.passwords`      | This helper will ensure required password for Redis&reg; are not empty. It returns a shared error for all the values. | `dict "secret" "redis-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use redis chart and the helper.                                                                                          |
-| `common.validations.values.cassandra.passwords`  | This helper will ensure required password for Cassandra are not empty. It returns a shared error for all the values.          | `dict "secret" "cassandra-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use cassandra chart and the helper.                                                                                  |
-| `common.validations.values.mongodb.passwords`    | This helper will ensure required password for MongoDB&reg; are not empty. It returns a shared error for all the values.            | `dict "secret" "mongodb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mongodb chart and the helper.                                                                                      |
-
-### Warnings
-
-| Helper identifier            | Description                      | Expected Input                                             |
-|------------------------------|----------------------------------|------------------------------------------------------------|
-| `common.warnings.rollingTag` | Warning about using rolling tag. | `ImageRoot` see [ImageRoot](#imageroot) for the structure. |
 
 ## Special input schemas
 
@@ -299,7 +184,7 @@ keyMapping:
 If we force those values to be empty we will see some alerts
 
 ```console
-$ helm install test mychart --set path.to.value00="",path.to.value01=""
+helm install test mychart --set path.to.value00="",path.to.value01=""
     'path.to.value00' must not be empty, please add '--set path.to.value00=$PASSWORD_00' to the command. To get the current value:
 
         export PASSWORD_00=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-00}" | base64 -d)
@@ -315,33 +200,33 @@ $ helm install test mychart --set path.to.value00="",path.to.value01=""
 
 [On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
-**What changes were introduced in this major version?**
+#### What changes were introduced in this major version?
 
 - Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
 - Use `type: library`. [Here](https://v3.helm.sh/docs/faq/#library-chart-support) you can find more information.
 - The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
 
-**Considerations when upgrading to this version**
+#### Considerations when upgrading to this version
 
 - If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
 - If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
 - If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
 
-**Useful links**
+#### Useful links
 
-- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
-- https://helm.sh/docs/topics/v2_v3_migration/
-- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+- <https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/>
+- <https://helm.sh/docs/topics/v2_v3_migration/>
+- <https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/>
 
 ## License
 
-Copyright &copy; 2022 Bitnami
+Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_affinities.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_affinities.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
@@ -46,47 +51,79 @@ Return a nodeAffinity definition
 {{- end -}}
 
 {{/*
+Return a topologyKey definition
+{{ include "common.affinities.topologyKey" (dict "topologyKey" "BAR") -}}
+*/}}
+{{- define "common.affinities.topologyKey" -}}
+{{ .topologyKey | default "kubernetes.io/hostname" -}}
+{{- end -}}
+
+{{/*
 Return a soft podAffinity/podAntiAffinity definition
-{{ include "common.affinities.pods.soft" (dict "component" "FOO" "extraMatchLabels" .Values.extraMatchLabels "context" $) -}}
+{{ include "common.affinities.pods.soft" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "context" $) -}}
 */}}
 {{- define "common.affinities.pods.soft" -}}
 {{- $component := default "" .component -}}
+{{- $customLabels := default (dict) .customLabels -}}
 {{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+{{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
 preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:
       labelSelector:
-        matchLabels: {{- (include "common.labels.matchLabels" .context) | nindent 10 }}
+        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 10 }}
           {{- if not (empty $component) }}
           {{ printf "app.kubernetes.io/component: %s" $component }}
           {{- end }}
           {{- range $key, $value := $extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
-      namespaces:
-        - {{ include "common.names.namespace" .context | quote }}
-      topologyKey: kubernetes.io/hostname
+      topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
     weight: 1
+  {{- range $extraPodAffinityTerms }}
+  - podAffinityTerm:
+      labelSelector:
+        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 10 }}
+          {{- if not (empty $component) }}
+          {{ printf "app.kubernetes.io/component: %s" $component }}
+          {{- end }}
+          {{- range $key, $value := .extraMatchLabels }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+      topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+    weight: {{ .weight | default 1 -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Return a hard podAffinity/podAntiAffinity definition
-{{ include "common.affinities.pods.hard" (dict "component" "FOO" "extraMatchLabels" .Values.extraMatchLabels "context" $) -}}
+{{ include "common.affinities.pods.hard" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "context" $) -}}
 */}}
 {{- define "common.affinities.pods.hard" -}}
 {{- $component := default "" .component -}}
+{{- $customLabels := default (dict) .customLabels -}}
 {{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
+{{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
 requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:
-      matchLabels: {{- (include "common.labels.matchLabels" .context) | nindent 8 }}
+      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 8 }}
         {{- if not (empty $component) }}
         {{ printf "app.kubernetes.io/component: %s" $component }}
         {{- end }}
         {{- range $key, $value := $extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-    namespaces:
-      - {{ include "common.names.namespace" .context | quote }}
-    topologyKey: kubernetes.io/hostname
+    topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+  {{- range $extraPodAffinityTerms }}
+  - labelSelector:
+      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 8 }}
+        {{- if not (empty $component) }}
+        {{ printf "app.kubernetes.io/component: %s" $component }}
+        {{- end }}
+        {{- range $key, $value := .extraMatchLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_capabilities.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_capabilities.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
@@ -45,6 +50,17 @@ Return the appropriate apiVersion for cronjob.
 {{- print "batch/v1beta1" -}}
 {{- else -}}
 {{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for daemonset.
+*/}}
+{{- define "common.capabilities.daemonset.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
 
@@ -138,6 +154,65 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 {{- end -}}
 {{- else -}}
 {{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Vertical Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.vpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if PodSecurityPolicy is supported
+*/}}
+{{- define "common.capabilities.psp.supported" -}}
+{{- if semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .) -}}
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true if AdmissionConfiguration is supported
+*/}}
+{{- define "common.capabilities.admissionConfiguration.supported" -}}
+{{- if semverCompare ">=1.23-0" (include "common.capabilities.kubeVersion" .) -}}
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for AdmissionConfiguration.
+*/}}
+{{- define "common.capabilities.admissionConfiguration.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiserver.config.k8s.io/v1alpha1" -}}
+{{- else if semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiserver.config.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiserver.config.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for PodSecurityConfiguration.
+*/}}
+{{- define "common.capabilities.podSecurityConfiguration.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "pod-security.admission.config.k8s.io/v1alpha1" -}}
+{{- else if semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "pod-security.admission.config.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "pod-security.admission.config.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_compatibility.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_compatibility.tpl
@@ -1,0 +1,39 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/* 
+Return true if the detected platform is Openshift
+Usage:
+{{- include "common.compatibility.isOpenshift" . -}}
+*/}}
+{{- define "common.compatibility.isOpenshift" -}}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" -}}
+{{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC
+Usage:
+{{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) -}}
+*/}}
+{{- define "common.compatibility.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+{{- if .context.Values.global.compatibility -}}
+  {{- if .context.Values.global.compatibility.openshift -}}
+    {{- if or (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "force") (and (eq .context.Values.global.compatibility.openshift.adaptSecurityContext "auto") (include "common.compatibility.isOpenshift" .context)) -}}
+      {{/* Remove incompatible user/group values that do not work in Openshift out of the box */}}
+      {{- $adaptedContext = omit $adaptedContext "fsGroup" "runAsUser" "runAsGroup" -}}
+      {{- if not .secContext.seLinuxOptions -}}
+      {{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+      {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_errors.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_errors.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Through error when upgrading using empty passwords values that must not be empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_images.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_images.tpl
@@ -1,7 +1,12 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Return the proper image name
-{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $) }}
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global ) }}
 */}}
 {{- define "common.images.image" -}}
 {{- $registryName := .imageRoot.registry -}}
@@ -17,7 +22,11 @@ Return the proper image name
     {{- $separator = "@" -}}
     {{- $termination = .imageRoot.digest | toString -}}
 {{- end -}}
-{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -29,19 +38,27 @@ Return the proper Docker Image Registry Secret Names (deprecated: use common.ima
 
   {{- if .global }}
     {{- range .global.imagePullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets . -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets .name -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end }}
     {{- end -}}
   {{- end -}}
 
   {{- range .images -}}
     {{- range .pullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets . -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets .name -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 
   {{- if (not (empty $pullSecrets)) }}
 imagePullSecrets:
-    {{- range $pullSecrets }}
+    {{- range $pullSecrets | uniq }}
   - name: {{ . }}
     {{- end }}
   {{- end }}
@@ -57,20 +74,44 @@ Return the proper Docker Image Registry Secret Names evaluating values as templa
 
   {{- if $context.Values.global }}
     {{- range $context.Values.global.imagePullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context)) -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 
   {{- range .images -}}
     {{- range .pullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+      {{- if kindIs "map" . -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" .name "context" $context)) -}}
+      {{- else -}}
+        {{- $pullSecrets = append $pullSecrets (include "common.tplvalues.render" (dict "value" . "context" $context)) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 
   {{- if (not (empty $pullSecrets)) }}
 imagePullSecrets:
-    {{- range $pullSecrets }}
+    {{- range $pullSecrets | uniq }}
   - name: {{ . }}
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Return the proper image version (ingores image revision/prerelease info & fallbacks to chart appVersion)
+{{ include "common.images.version" ( dict "imageRoot" .Values.path.to.the.image "chart" .Chart ) }}
+*/}}
+{{- define "common.images.version" -}}
+{{- $imageTag := .imageRoot.tag | toString -}}
+{{/* regexp from https://github.com/Masterminds/semver/blob/23f51de38a0866c5ef0bfc42b3f735c73107b700/version.go#L41-L44 */}}
+{{- if regexMatch `^([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$` $imageTag -}}
+    {{- $version := semver $imageTag -}}
+    {{- printf "%d.%d.%d" $version.Major $version.Minor $version.Patch -}}
+{{- else -}}
+    {{- print .chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_ingress.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_ingress.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
@@ -62,7 +67,7 @@ Usage:
 {{ include "common.ingress.certManagerRequest" ( dict "annotations" .Values.path.to.the.ingress.annotations ) }}
 */}}
 {{- define "common.ingress.certManagerRequest" -}}
-{{ if or (hasKey .annotations "cert-manager.io/cluster-issuer") (hasKey .annotations "cert-manager.io/issuer") }}
+{{ if or (hasKey .annotations "cert-manager.io/cluster-issuer") (hasKey .annotations "cert-manager.io/issuer") (hasKey .annotations "kubernetes.io/tls-acme") }}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_labels.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_labels.tpl
@@ -1,18 +1,46 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Kubernetes standard labels
+{{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) -}}
 */}}
 {{- define "common.labels.standard" -}}
+{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
+{{- $default := dict "app.kubernetes.io/name" (include "common.names.name" .context) "helm.sh/chart" (include "common.names.chart" .context) "app.kubernetes.io/instance" .context.Release.Name "app.kubernetes.io/managed-by" .context.Release.Service -}}
+{{- with .context.Chart.AppVersion -}}
+{{- $_ := set $default "app.kubernetes.io/version" . -}}
+{{- end -}}
+{{ template "common.tplvalues.merge" (dict "values" (list .customLabels $default) "context" .context) }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "common.names.name" . }}
 helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+Labels used on immutable fields such as deploy.spec.selector.matchLabels or svc.spec.selector
+{{ include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $) -}}
+
+We don't want to loop over custom labels appending them to the selector
+since it's very likely that it will break deployments, services, etc.
+However, it's important to overwrite the standard labels if the user
+overwrote them on metadata.labels fields.
 */}}
 {{- define "common.labels.matchLabels" -}}
+{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
+{{ merge (pick (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) "app.kubernetes.io/name" "app.kubernetes.io/instance") (dict "app.kubernetes.io/name" (include "common.names.name" .context) "app.kubernetes.io/instance" .context.Release.Name ) | toYaml }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "common.names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_names.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_names.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
@@ -55,11 +60,7 @@ Usage:
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
 */}}
 {{- define "common.names.namespace" -}}
-{{- if .Values.namespaceOverride -}}
-{{- .Values.namespaceOverride -}}
-{{- else -}}
-{{- .Release.Namespace -}}
-{{- end -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_resources.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_resources.tpl
@@ -1,0 +1,50 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return a resource request/limit object based on a given preset.
+These presets are for basic testing and not meant to be used in production
+{{ include "common.resources.preset" (dict "type" "nano") -}}
+*/}}
+{{- define "common.resources.preset" -}}
+{{/* The limits are the requests increased by 50% (except ephemeral-storage and xlarge/2xlarge sizes)*/}}
+{{- $presets := dict 
+  "nano" (dict 
+      "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "1024Mi")
+   )
+  "micro" (dict 
+      "requests" (dict "cpu" "250m" "memory" "256Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "375m" "memory" "384Mi" "ephemeral-storage" "1024Mi")
+   )
+  "small" (dict 
+      "requests" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "750m" "memory" "768Mi" "ephemeral-storage" "1024Mi")
+   )
+  "medium" (dict 
+      "requests" (dict "cpu" "500m" "memory" "1024Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "750m" "memory" "1536Mi" "ephemeral-storage" "1024Mi")
+   )
+  "large" (dict 
+      "requests" (dict "cpu" "1.0" "memory" "2048Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "1024Mi")
+   )
+  "xlarge" (dict 
+      "requests" (dict "cpu" "1.5" "memory" "4096Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "1024Mi")
+   )
+  "2xlarge" (dict 
+      "requests" (dict "cpu" "1.5" "memory" "4096Mi" "ephemeral-storage" "50Mi")
+      "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "1024Mi")
+   )
+ }}
+{{- if hasKey $presets .type -}}
+{{- index $presets .type | toYaml -}}
+{{- else -}}
+{{- printf "ERROR: Preset key '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end -}}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_secrets.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_secrets.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Generate secret name.
@@ -8,7 +13,7 @@ Usage:
 Params:
   - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
     to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
-    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+    +info: https://github.com/bitnami/charts/tree/main/bitnami/common#existingsecret
   - defaultNameSuffix - String - Optional. It is used only if we have several secrets in the same deployment.
   - context - Dict - Required. The context for the template evaluation.
 */}}
@@ -41,7 +46,7 @@ Usage:
 Params:
   - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
     to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
-    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+    +info: https://github.com/bitnami/charts/tree/main/bitnami/common#existingsecret
   - key - String - Required. Name of the key in the secret.
 */}}
 {{- define "common.secrets.key" -}}
@@ -72,7 +77,9 @@ Params:
   - strong - Boolean - Optional - Whether to add symbols to the generated random password.
   - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
   - context - Context - Required - Parent context.
-
+  - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
+  - skipB64enc - Boolean - Optional - Default to false. If set to true, no the secret will not be base64 encrypted.
+  - skipQuote - Boolean - Optional - Default to false. If set to true, no quotes will be added around the secret.
 The order in which this function returns a secret password:
   1. Already existing 'Secret' resource
      (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
@@ -90,15 +97,17 @@ The order in which this function returns a secret password:
 {{- $passwordLength := default 10 .length }}
 {{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
 {{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
-{{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data }}
+{{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data }}
 {{- if $secretData }}
   {{- if hasKey $secretData .key }}
-    {{- $password = index $secretData .key }}
-  {{- else }}
+    {{- $password = index $secretData .key | b64dec }}
+  {{- else if not (eq .failOnNew false) }}
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
+  {{- else if $providedPasswordValue }}
+    {{- $password = $providedPasswordValue | toString }}
   {{- end -}}
 {{- else if $providedPasswordValue }}
-  {{- $password = $providedPasswordValue | toString | b64enc | quote }}
+  {{- $password = $providedPasswordValue | toString }}
 {{- else }}
 
   {{- if .context.Values.enabled }}
@@ -114,12 +123,45 @@ The order in which this function returns a secret password:
     {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
     {{- $password = randAscii $passwordLength }}
     {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
-    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc | quote }}
+    {{- $password = printf "%s%s" $subStr $password | toString | shuffle }}
   {{- else }}
-    {{- $password = randAlphaNum $passwordLength | b64enc | quote }}
+    {{- $password = randAlphaNum $passwordLength }}
   {{- end }}
 {{- end -}}
+{{- if not .skipB64enc }}
+{{- $password = $password | b64enc }}
+{{- end -}}
+{{- if .skipQuote -}}
 {{- printf "%s" $password -}}
+{{- else -}}
+{{- printf "%s" $password | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Reuses the value from an existing secret, otherwise sets its value to a default value.
+
+Usage:
+{{ include "common.secrets.lookup" (dict "secret" "secret-name" "key" "keyName" "defaultValue" .Values.myValue "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - defaultValue - String - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - context - Context - Required - Parent context.
+
+*/}}
+{{- define "common.secrets.lookup" -}}
+{{- $value := "" -}}
+{{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data -}}
+{{- if and $secretData (hasKey $secretData .key) -}}
+  {{- $value = index $secretData .key -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString | b64enc -}}
+{{- end -}}
+{{- if $value -}}
+{{- printf "%s" $value -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -133,7 +175,7 @@ Params:
   - context - Context - Required - Parent context.
 */}}
 {{- define "common.secrets.exists" -}}
-{{- $secret := (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
+{{- $secret := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret) }}
 {{- if $secret }}
   {{- true -}}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_storage.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_storage.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Return  the proper Storage Class

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_tplvalues.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_tplvalues.tpl
@@ -1,13 +1,38 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Renders a value that contains template.
+Renders a value that contains template perhaps with scope if the scope is present.
 Usage:
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
 */}}
 {{- define "common.tplvalues.render" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_utils.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_utils.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Print instructions to get a secret value.
@@ -6,7 +11,7 @@ Usage:
 */}}
 {{- define "common.utils.secret.getvalue" -}}
 {{- $varname := include "common.utils.fieldToEnvVar" . -}}
-export {{ $varname }}=$(kubectl get secret --namespace {{ .context.Release.Namespace | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 -d)
+export {{ $varname }}=$(kubectl get secret --namespace {{ include "common.names.namespace" .context | quote }} {{ .secret }} -o jsonpath="{.data.{{ .field }}}" | base64 -d)
 {{- end -}}
 
 {{/*
@@ -59,4 +64,14 @@ Usage:
   {{- end -}}
 {{- end -}}
 {{- printf "%s" $key -}} 
+{{- end -}}
+
+{{/*
+Checksum a template at "path" containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376).
+Usage:
+{{ include "common.utils.checksumTemplate" (dict "path" "/configmap.yaml" "context" $) }}
+*/}}
+{{- define "common.utils.checksumTemplate" -}}
+{{- $obj := include (print .context.Template.BasePath .path) .context | fromYaml -}}
+{{ omit $obj "apiVersion" "kind" "metadata" | toYaml | sha256sum }}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_warnings.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/_warnings.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Warning about using rolling tag.
@@ -8,7 +13,70 @@ Usage:
 
 {{- if and (contains "bitnami/" .repository) (not (.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
++info https://docs.bitnami.com/tutorials/understand-rolling-tags-containers
 {{- end }}
+{{- end -}}
 
+{{/*
+Warning about not setting the resource object in all deployments.
+Usage:
+{{ include "common.warnings.resources" (dict "sections" (list "path1" "path2") context $) }}
+Example:
+{{- include "common.warnings.resources" (dict "sections" (list "csiProvider.provider" "server" "volumePermissions" "") "context" $) }}
+The list in the example assumes that the following values exist:
+  - csiProvider.provider.resources
+  - server.resources
+  - volumePermissions.resources
+  - resources
+*/}}
+{{- define "common.warnings.resources" -}}
+{{- $values := .context.Values -}}
+{{- $printMessage := false -}}
+{{ $affectedSections := list -}}
+{{- range .sections -}}
+  {{- if eq . "" -}}
+    {{/* Case where the resources section is at the root (one main deployment in the chart) */}}
+    {{- if not (index $values "resources") -}}
+    {{- $affectedSections = append $affectedSections "resources" -}}
+    {{- $printMessage = true -}}
+    {{- end -}}
+  {{- else -}}
+    {{/* Case where the are multiple resources sections (more than one main deployment in the chart) */}}
+    {{- $keys := split "." . -}}
+    {{/* We iterate through the different levels until arriving to the resource section. Example: a.b.c.resources */}}
+    {{- $section := $values -}}
+    {{- range $keys -}}
+      {{- $section = index $section . -}}
+    {{- end -}}
+    {{- if not (index $section "resources") -}}
+      {{/* If the section has enabled=false or replicaCount=0, do not include it */}}
+      {{- if and (hasKey $section "enabled") -}}
+        {{- if index $section "enabled" -}}
+          {{/* enabled=true */}}
+          {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+          {{- $printMessage = true -}}
+        {{- end -}}
+      {{- else if and (hasKey $section "replicaCount")  -}}
+        {{/* We need a casting to int because number 0 is not treated as an int by default */}}
+        {{- if (gt (index $section "replicaCount" | int) 0) -}}
+          {{/* replicaCount > 0 */}}
+          {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+          {{- $printMessage = true -}}
+        {{- end -}}
+      {{- else -}}
+        {{/* Default case, add it to the affected sections */}}
+        {{- $affectedSections = append $affectedSections (printf "%s.resources" .) -}}
+        {{- $printMessage = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $printMessage }}
+
+WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
+{{- range $affectedSections }}
+  - {{ . }}
+{{- end }}
++info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+{{- end -}}
 {{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_cassandra.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_cassandra.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate Cassandra required passwords are not empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mariadb.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mariadb.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate MariaDB required passwords are not empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mongodb.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mongodb.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate MongoDB&reg; required passwords are not empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mysql.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_mysql.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate MySQL required passwords are not empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_postgresql.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_postgresql.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate PostgreSQL required passwords are not empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_redis.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_redis.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 
 {{/* vim: set filetype=mustache: */}}
 {{/*

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_validations.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/templates/validations/_validations.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Validate values must not be empty.

--- a/agrold-javaweb/charts/agrold-javaweb/charts/common/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/charts/common/values.yaml
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 ## bitnami/common
 ## It is required by CI/CD tools and processes.
 ## @skip exampleValue

--- a/agrold-javaweb/charts/agrold-javaweb/templates/NOTES.txt
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/NOTES.txt
@@ -48,10 +48,4 @@ APP VERSION: {{ .Chart.AppVersion }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.tomcat-password}" | base64 -d)
 
 {{- include "tomcat.checkRollingTags" . }}
-{{- $passwordValidationErrors := list -}}
-{{- $secretName := include "common.names.fullname" . -}}
-{{- $requiredTomcatPassword := dict "valueKey" "tomcatPassword" "secret" $secretName "field" "tomcat-password" "context" $ -}}
-{{- $requiredTomcatPasswordError := include "common.validations.values.single.empty" $requiredTomcatPassword -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $requiredTomcatPasswordError -}}
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
-{{- include "tomcat.validateValues" . -}}
+{{- include "common.warnings.resources" (dict "sections" (list "metrics.jmx" "" "volumePermissions") "context" $) }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
@@ -1,3 +1,8 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
@@ -43,11 +48,29 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return the Tomcat credential secret name
+*/}}
+{{- define "tomcat.secretName" -}}
+{{- coalesce .Values.existingSecret (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{/*
 Check if there are rolling tags in the images
 */}}
 {{- define "tomcat.checkRollingTags" -}}
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
+{{- end -}}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "tomcat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/agrold-javaweb/charts/agrold-javaweb/templates/deployment.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/deployment.yaml
@@ -1,27 +1,27 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{ if (or (not .Values.persistence.enabled) (eq .Values.deployment.type "deployment")) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
-      labels: {{- include "common.labels.standard" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
-        {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/extra-list.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/extra-list.yaml
@@ -1,3 +1,8 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- range .Values.extraDeploy }}
 ---
 {{ include "common.tplvalues.render" (dict "value" . "context" $) }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/ingress.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/ingress.yaml
@@ -1,23 +1,23 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if .Values.ingress.enabled }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingress.annotations .Values.commonAnnotations ) "context" . ) }}
+    {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/agrold-javaweb/charts/agrold-javaweb/templates/jmx-configmap.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/jmx-configmap.yaml
@@ -1,13 +1,15 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.metrics.jmx.enabled .Values.metrics.jmx.config (not .Values.metrics.jmx.existingConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "tomcat.fullname" . }}-jmx-configuration
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/networkpolicy.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/networkpolicy.yaml
@@ -1,40 +1,92 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
-    matchLabels:
-    {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to MariaDB
+    - ports:
+        - port: {{ include "wordpress.databasePort" . }}
+      {{- if .Values.mariadb.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mariadb
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- if .Values.wordpressConfigureCache }}
+    # Allow outbound connections to Memcached
+    - ports:
+        - port: {{ include "wordpress.cachePort" . }}
+      {{- if .Values.memcached.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: memcached
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
   ingress:
-    # Allow inbound connections
     - ports: {{- include "tomcat.ports" . | nindent 8 }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:
-            matchLabels:
-              {{ template "common.names.fullname" . }}-client: "true"
-          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
-          namespaceSelector:
-{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
-          {{- end }}
-    # Allow communication between Tomcat's POD
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         - podSelector:
             matchLabels:
-            {{- include "common.labels.matchLabels" . | nindent 14 }}
+              {{ template "common.names.fullname" . }}-client: "true"
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
       {{- end }}
     {{- if .Values.metrics.jmx.enabled }}
     # Allow prometheus scrapes
     - ports:
         - port: {{ .Values.metrics.jmx.ports.metrics }}
+    {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/podmonitor.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/podmonitor.yaml
@@ -1,13 +1,15 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.metrics.jmx.enabled .Values.metrics.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.podMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.podMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podMonitor.additionalLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -35,7 +37,7 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
-    matchLabels:
-      {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
 {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/prometheusrule.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/prometheusrule.yaml
@@ -1,19 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.metrics.jmx.enabled .Values.metrics.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "common.names.fullname" . }}
-{{- with .Values.metrics.prometheusRule.namespace }}
-  namespace: {{ . }}
-{{- end }}
-  labels:
-  {{- include "common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
-  {{- with .Values.metrics.prometheusRule.additionalLabels }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/pvc.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/pvc.yaml
@@ -1,13 +1,15 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "deployment") -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/secrets.yaml
@@ -1,20 +1,20 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- if .Values.tomcatPassword }}
-  tomcat-password: {{ .Values.tomcatPassword | b64enc | quote }}
-  {{- else }}
-  tomcat-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{- end }}
+  tomcat-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "tomcat-password" "providedValues" (list "tomcatPassword") "length" 10 "strong" false "context" $) }}
   catalinaOpts: {{ include "tomcat.catalinaOpts" . | b64enc | quote }}
+{{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/serviceaccount.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tomcat.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/statefulset.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/statefulset.yaml
@@ -1,13 +1,15 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset") }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -16,16 +18,14 @@ spec:
   {{- if .Values.podManagementPolicy }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   serviceName: {{ template "common.names.fullname" . }}-headless
   template:
     metadata:
-      labels: {{- include "common.labels.standard" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
-        {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/svc-headless.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/svc-headless.yaml
@@ -1,24 +1,22 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset") }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}-headless
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  annotations:
-    {{- if .Values.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.service.headless.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   clusterIP: None
   type: ClusterIP
-  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
 {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/svc.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/svc.yaml
@@ -1,20 +1,17 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
-  annotations:
-    {{- if .Values.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-    {{- end }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -48,4 +45,5 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/agrold-javaweb/charts/agrold-javaweb/templates/tls-secrets.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/tls-secrets.yaml
@@ -1,3 +1,8 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
 {{- if .Values.ingress.enabled }}
 {{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
@@ -6,12 +11,9 @@ kind: Secret
 metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- if $.Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:
@@ -21,24 +23,22 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
 {{- $ca := genCA "tomcat-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/agrold-javaweb/charts/agrold-javaweb/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/values.yaml
@@ -1,25 +1,13 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 ##
 
-## @param global.imageRegistry Global Docker image registry
-## @param global.imagePullSecrets Global Docker registry secret names as an array
-## @param global.storageClass Global StorageClass for Persistent Volume(s)
-##
-global:
-  imageRegistry: "ghcr.io/southgreenplatform/agrold:2.0.0"
-  ## E.g.
-  ## imagePullSecrets:
-  ##   - myRegistryKeySecretName
-  ##
-  imagePullSecrets: []
-  storageClass: ""
-
-# use this to configure agrold you can read it's configuration at https://github.com/SouthGreenPlatform/AgroLD_webapp/blob/master/agrold-javaweb/README.md#param%C3%A8tres
-
-agroldProperties: 
+agroldProperties:
   # The property below is set to ingress.hostname, set this value to override it
   # baseurl: "http://agrold.org"
   db_connection_url: someurl
@@ -28,6 +16,27 @@ agroldProperties:
   rf_link: https://rf.someurl.fr
   description: ""
 
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+  ## Compatibility adaptations for Kubernetes platforms
+  ##
+  compatibility:
+    ## Compatibility adaptations for Openshift
+    ##
+    openshift:
+      ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+      ##
+      adaptSecurityContext: disabled
 ## @section Common parameters
 ##
 
@@ -51,28 +60,28 @@ commonAnnotations: {}
 clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
-extraDeploy: [ ]
+extraDeploy: []
 ## @section Tomcat parameters
 ##
 
 ## Bitnami Tomcat image version
 ## ref: https://hub.docker.com/r/bitnami/tomcat/tags/
-## @param image.registry Tomcat image registry
-## @param image.repository Tomcat image repository
-## @param image.tag Tomcat image tag (immutable tags are recommended)
+## @param image.registry [default: REGISTRY_NAME] Tomcat image registry
+## @param image.repository [default: REPOSITORY_NAME/tomcat] Tomcat image repository
+## @skip image.tag Tomcat image tag (immutable tags are recommended)
 ## @param image.digest Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Tomcat image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug logs should be enabled
 ##
 image:
-  registry: docker.io
-  repository: bitnami/tomcat
-  tag: 8.5.83-debian-11-r14
+  registry: ghcr.io
+  repository: southgreenplatform/agrold
+  tag: 2.0.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
   ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -86,6 +95,9 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -98,8 +110,11 @@ tomcatUsername: manager
 ## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
 ##
 tomcatPassword: "password"
+## @param existingSecret Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the key `tomcat-password`
+##
+existingSecret: ""
 ## @param tomcatAllowRemoteManagement Enable remote access to management interface
-## ref: https://github.com/bitnami/charts/tree/master/bitnami/tomcat#configuration
+## ref: https://github.com/bitnami/charts/tree/main/bitnami/tomcat#configuration
 ##
 tomcatAllowRemoteManagement: 1
 ## @param catalinaOpts Java runtime option used by tomcat JVM
@@ -159,40 +174,64 @@ containerExtraPorts: []
 ## Tomcat pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param podSecurityContext.enabled Enable Tomcat pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Tomcat pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Tomcat containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-## @param containerSecurityContext.enabled Enable Tomcat containers' SecurityContext
-## @param containerSecurityContext.runAsUser User ID for the Tomcat container
-## @param containerSecurityContext.runAsNonRoot Force user to be root in Tomcat container
+## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+## @param containerSecurityContext.runAsGroup Set containers' Security Context runAsGroup
+## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set container's Security Context privileged
+## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
+  runAsGroup: 1001
   runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
 ## Tomcat containers' resource requests and limits
-## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 ## We usually recommend not to specify default resources and to leave this as a conscious
 ## choice for the user. This also increases chances charts run on environments with little
 ## resources, such as Minikube. If you do want to specify resources, uncomment the following
 ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param resources.limits The resources limits for the Tomcat container
-## @param resources.requests [object] The requested resources for the Tomcat container
+## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
+## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
 ##
-resources:
-  ## Example:
-  ## limits:
-  ##    cpu: 500m
-  ##    memory: 1Gi
-  ##
-  limits: {}
-  requests:
-    cpu: 300m
-    memory: 512Mi
+resourcesPreset: "micro"
+## @param resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+## Example:
+## resources:
+##   requests:
+##     cpu: 2
+##     memory: 512Mi
+##   limits:
+##     cpu: 3
+##     memory: 1024Mi
+##
+resources: {}
 ## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe
@@ -291,7 +330,7 @@ nodeAffinityPreset:
 ##
 affinity: {}
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
-## ref: https://kubernetes.io/docs/user-guide/node-selection/
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 ##
 nodeSelector: {}
 ## @param schedulerName Alternative scheduler
@@ -319,19 +358,12 @@ extraPodSpec: {}
 ## @param extraVolumes Optionally specify extra list of additional volumes for Tomcat pods in Deployment
 ##
 extraVolumes: []
-  # - name: webapps
-  #   configMap:
-  #     name: apps 
-
 ## @param extraVolumeClaimTemplates Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet
 ##
 extraVolumeClaimTemplates: []
 ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Tomcat container(s)
 ##
 extraVolumeMounts: []
-  # - name: webapps
-  #   mountPath: /mnt
-
 ## @param initContainers Add init containers to the Tomcat pods.
 ## Example:
 ## initContainers:
@@ -355,7 +387,7 @@ initContainers: []
 ##
 sidecars: []
 ## Enable persistence using Persistent Volume Claims
-## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 ##
 persistence:
   ## @param persistence.enabled Enable persistence
@@ -386,31 +418,79 @@ persistence:
   ## Applicable when deployment.type is statefulset
   ##
   selectorLabels: {}
+## Network Policy configuration
+## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
 networkPolicy:
-  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
   ##
-  enabled: false
-  ## @param networkPolicy.allowExternal Don't require client label for connections
+  enabled: true
+  ## @param networkPolicy.allowExternal Don't require server label for connections
   ## The Policy model to apply. When set to false, only pods with the correct
-  ## client label will have network access to every tomcat port defined on containerPort and containerExtraPorts.
-  ## When true, tomcat will accept connections from any source
+  ## server label will have network access to the ports server is listening
+  ## on. When true, server will accept connections from any source
   ## (with the correct destination port).
   ##
   allowExternal: true
-  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
-  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that have the good label, can reach the tomcat.
-  ## But sometimes, we want the tomcat to be accessible to clients from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
   ##
-  ## Example:
-  ## explicitNamespacesSelector:
-  ##   matchLabels:
-  ##     role: frontend
-  ##   matchExpressions:
-  ##    - {key: role, operator: In, values: [frontend]}
+  allowExternalEgress: true
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
   ##
-  explicitNamespacesSelector: {}
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Tomcat pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 ## @section Traffic Exposure parameters
 ##
 
@@ -468,6 +548,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## Headless service properties
+  ##
+  headless:
+    ## @param service.headless.annotations Annotations for the headless service.
+    ##
+    annotations: {}
 ## Ingress configuratiom
 ##
 ingress:
@@ -483,7 +569,7 @@ ingress:
   hostname: vmagrold-proto
   ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md
   ## Use this parameter to set the required annotations for cert-manager, see
   ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
   ##
@@ -572,7 +658,6 @@ ingress:
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
-
 ## @section Volume Permissions parameters
 ##
 
@@ -583,17 +668,17 @@ volumePermissions:
   ## @param volumePermissions.enabled Enable init container that changes volume permissions in the data directory
   ##
   enabled: false
-  ## @param volumePermissions.image.registry Init container volume-permissions image registry
-  ## @param volumePermissions.image.repository Init container volume-permissions image repository
-  ## @param volumePermissions.image.tag Init container volume-permissions image tag
+  ## @param volumePermissions.image.registry [default: REGISTRY_NAME] Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository [default: REPOSITORY_NAME/os-shell] Init container volume-permissions image repository
+  ## @skip volumePermissions.image.tag Init container volume-permissions image tag
   ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r36
+    repository: bitnami/os-shell
+    tag: 12-debian-12-r17
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -605,28 +690,26 @@ volumePermissions:
     ##
     pullSecrets: []
   ## Init container' resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
   ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param volumePermissions.resources.limits Init container volume-permissions resource  limits
-  ## @param volumePermissions.resources.requests Init container volume-permissions resource  requests
+  ## @param volumePermissions.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    ##
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    ##
-    requests: {}
-
+  resourcesPreset: "none"
+  ## @param volumePermissions.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 2
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 3
+  ##     memory: 1024Mi
+  ##
+  resources: {}
 ## @section Metrics parameters
 
 ## Prometheus Exporters / Metrics
@@ -643,9 +726,9 @@ metrics:
     catalinaOpts: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true
     ## Bitnami JMX exporter image
     ## ref: https://hub.docker.com/r/bitnami/jmx-exporter/tags/
-    ## @param metrics.jmx.image.registry JMX exporter image registry
-    ## @param metrics.jmx.image.repository JMX exporter image repository
-    ## @param metrics.jmx.image.tag JMX exporter image tag (immutable tags are recommended)
+    ## @param metrics.jmx.image.registry [default: REGISTRY_NAME] JMX exporter image registry
+    ## @param metrics.jmx.image.repository [default: REPOSITORY_NAME/jmx-exporter] JMX exporter image repository
+    ## @skip metrics.jmx.image.tag JMX exporter image tag (immutable tags are recommended)
     ## @param metrics.jmx.image.digest JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param metrics.jmx.image.pullPolicy JMX exporter image pull policy
     ## @param metrics.jmx.image.pullSecrets Specify docker-registry secret names as an array
@@ -653,11 +736,11 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.17.1-debian-11-r2
+      tag: 0.20.0-debian-12-r12
       digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-      ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
       ##
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
@@ -679,33 +762,50 @@ metrics:
       attrNameSnakeCase: true
     ## Prometheus JMX exporter containers' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    ## @param metrics.jmx.containerSecurityContext.enabled Enable Prometheus JMX exporter containers' Security Context
-    ## @param metrics.jmx.containerSecurityContext.runAsUser Set Prometheus JMX exporter containers' Security Context runAsUser
-    ## @param metrics.jmx.containerSecurityContext.runAsNonRoot Set Prometheus JMX exporter containers' Security Context runAsNonRoot
+    ## @param metrics.jmx.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param metrics.jmx.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
+    ## @param metrics.jmx.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+    ## @param metrics.jmx.containerSecurityContext.runAsGroup Set containers' Security Context runAsGroup
+    ## @param metrics.jmx.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+    ## @param metrics.jmx.containerSecurityContext.privileged Set container's Security Context privileged
+    ## @param metrics.jmx.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+    ## @param metrics.jmx.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+    ## @param metrics.jmx.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+    ## @param metrics.jmx.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
     containerSecurityContext:
       enabled: true
+      seLinuxOptions: {}
       runAsUser: 1001
+      runAsGroup: 1001
       runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     ## Prometheus JMX Exporter' resource requests and limits
-    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     ## We usually recommend not to specify default resources and to leave this as a conscious
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ## @param metrics.jmx.resources.limits JMX Exporter container resource limits
-    ## @param metrics.jmx.resources.requests JMX Exporter container resource requests
+    ## @param metrics.jmx.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if metrics.jmx.resources is set (metrics.jmx.resources is recommended for production).
+    ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
     ##
-    resources:
-      ## Example:
-      ## limits:
-      ##    cpu: 100m
-      ##    memory: 128Mi
-      limits: {}
-      ## Examples:
-      ## requests:
-      ##    cpu: 100m
-      ##    memory: 128Mi
-      requests: {}
+    resourcesPreset: "none"
+    ## @param metrics.jmx.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    ## Example:
+    ## resources:
+    ##   requests:
+    ##     cpu: 2
+    ##     memory: 512Mi
+    ##   limits:
+    ##     cpu: 3
+    ##     memory: 1024Mi
+    ##
+    resources: {}
     ## @param metrics.jmx.ports.metrics JMX Exporter container metrics ports
     ##
     ports:

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>agrold</groupId>
     <artifactId>agrold</artifactId>
-    <version>1.0</version>
+    <version>2.1.0</version>
     <packaging>war</packaging>
 
 


### PR DESCRIPTION
This release aims to fix the deployment charts to comply with [security defaults](https://github.com/bitnami/charts/issues/24251). With #65 it: 

- upgrades Bitnami's Helm chart to 11.0
- changes Tomcat version to 8.5

It also changes the CICD so tagging triggers a helm deployment (#66)