### PR TITLE
bump to 2.1.1

### DIFF
--- a/.github/workflows/test_helm_chart.yaml
+++ b/.github/workflows/test_helm_chart.yaml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Helm Check Action
         uses: hopisaurus/helm-check-action@v0.1.0

--- a/agrold-javaweb/Dockerfile
+++ b/agrold-javaweb/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.9-amazoncorretto-8 as build
+FROM maven:3.9-amazoncorretto-17 as build
 # Shared arguments between build and run stages
 
 ARG AGROLD_NAME=aldp
@@ -11,7 +11,7 @@ COPY . /build_dir
 RUN mvn clean install -Dagrold.name=${AGROLD_NAME}
 
 # Run stage
-FROM bitnami/tomcat:8.5
+FROM bitnami/tomcat:9.0
 
 ARG GIT_COMMIT=unknown
 ARG AGROLD_NAME=aldp

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -6,7 +6,6 @@
 
 - `git clone --branch dev`
 
-
 Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur le Notion](https://agrold-wiki.notion.site/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5)
 
 ### Deployer l'appli web
@@ -23,15 +22,15 @@ Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur
 
 Le déploiement de l'application se fait premièrement avec des propriétés Java passées à tomcat.
 
-|            Name            |                                                                    Description                                                                    |       Valeur par défaut       |
-| :------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------: |
+|            Name            |                                Description                                 |       Valeur par défaut       |
+| :------------------------: | :------------------------------------------------------------------------: | :---------------------------: |
 |       `agrold.name`        | Nom de l'archive et du contexte `aldp` on a `https://<un domaine>/agrold`) |            `aldp`             |
-|    `agrold.description`    |                                                         Description affichée dans Tomcat                                                          |              :x:              |
-|  `agrold.sparql_endpoint`  |                                                             Url de l'endpoint SPARQL                                                              | `http://sparql.southgreen.fr` |
-| `agrold.db_connection_url` |                                             Url de la base de données ex: `[host]:[port]/[db]?[opt]`                                              |         :x: (requis)          |
-|    `agrold.db_username`    |                                                         Utilisateur de la base de données                                                         |         :x: (requis)          |
-|    `agrold.db_password`    |                                                        Mot de passe de la base de données                                                         |         :x: (requis)          |
-|      `agrold.rf_link`      |                                                   Lien vers une instance de RelFinder[Reformed]                                                   |  `http://rf.southgreen.fr/`   |
+|    `agrold.description`    |                      Description affichée dans Tomcat                      |              :x:              |
+|  `agrold.sparql_endpoint`  |                          Url de l'endpoint SPARQL                          | `http://sparql.southgreen.fr` |
+| `agrold.db_connection_url` |          Url de la base de données ex: `[host]:[port]/[db]?[opt]`          |              :x:              |
+|    `agrold.db_username`    |                     Utilisateur de la base de données                      |              :x:              |
+|    `agrold.db_password`    |                     Mot de passe de la base de données                     |              :x:              |
+|      `agrold.rf_link`      |               Lien vers une instance de RelFinder[Reformed]                |  `http://rf.southgreen.fr/`   |
 
 Pour injecter ces variables dans tomcat, il faut déclarer les sous forme d'argument en ligne de commande sous cette forme `-Dnomdelapropriété=valeur` et les placer dans la variable d'environnement `CATALINA_OPTS`
 
@@ -42,16 +41,8 @@ Par exemple:
 
 ```bash
 # Directement sur l'hôte
-export CATALINA_OPTS="-Dagrold.db_connection_url=someurlhere -Dagrold.db_username=usr -Dagrold.db_password=pwd"
+export CATALINA_OPTS="-Dagrold.blabla=valeur"
 catalina.sh
-```
-
-```java
-...
-String URL = System.getProperty("agrold.db_connection_url");
-String usr = System.getProperty("agrold.db_username");
-String pwd = System.getProperty("agrold.db_password");
-...
 ```
 
 Si vous lancez tomcat avec systemd le remplissage des variables d'environnement se fait ainsi
@@ -61,7 +52,7 @@ sudo systemctl edit tomcat8 #ou tomcat7/9
 
 # dans l'éditeur
 [Service]
-Environment="CATALINA_OPTS='-Dagrold.db_connection_url=someurlhere -Dagrold.db_username=usr -Dagrold.db_password=pwd'"
+Environment="CATALINA_OPTS='-Dagrold.blabla=valeur'"
 ```
 
 Pour compiler lancez maven à la racine du projet, Il est possible de passer la propriété `agrold.name` en argument de maven
@@ -73,7 +64,6 @@ mvn clean install
 
 mvn clean install -Dagrold.name=un_nom # vous accéderez à l'application via https://<votre url>/un_nom
 ```
-
 
 Si vous utilisez docker:
 
@@ -89,7 +79,7 @@ docker login 10.9.2.21:8080 -u <user> -p <password>
 docker pull 10.9.2.21:8080
 
 # Lancer le conteneur
-docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.sparql_endpoint=a" <tag>
+docker run -p 8080:8080 <tag>
 ```
 
 > [!NOTE]

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -4,8 +4,8 @@
 
 ### Cloner l'appli
 
-- `git clone --branch dev `
--
+- `git clone --branch dev`
+
 
 Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur le Notion](https://agrold-wiki.notion.site/Configurer-et-utiliser-son-IDE-pour-les-projets-cbf2dc48224f48009a9c0775a173a6d5)
 
@@ -13,8 +13,11 @@ Vous pourrez voir comment paramétrer votre IDE dans [la section appropriée sur
 
 #### Pré requis
 
-- Tomcat 7/8
+- Tomcat 7/8/9
+- JDK 17
+- Maven
 - mysql (sera bientôt agnostique ou retiré)
+- Docker (optionnel)
 
 #### Paramètres
 
@@ -55,7 +58,7 @@ String pwd = System.getProperty("agrold.db_password");
 Si vous lancez tomcat avec systemd le remplissage des variables d'environnement se fait ainsi
 
 ```bash
-sudo systemctl edit tomcat8 #ou tomcat7
+sudo systemctl edit tomcat8 #ou tomcat7/9
 
 # dans l'éditeur
 [Service]
@@ -72,7 +75,6 @@ mvn clean install
 mvn clean install -Dagrold.name=un_nom # vous accéderez à l'application via https://<votre url>/un_nom
 ```
 
-````
 
 Si vous utilisez docker:
 
@@ -80,8 +82,8 @@ Si vous utilisez docker:
 cd agrold-javaweb/
 
 # Vous pouvez utiliser le dockerfile
-#                          le mot de passe du manager
-docker build . -t <tag> --build-arg TOMCAT_PASSWORD=a --build-arg AGROLD_NAME=agrolddev
+#                          la valeur de agrold.name
+docker build . -t <tag> --build-arg AGROLD_NAME=agrolddev
 
 # Ou pull l'image stockée depuis le registre dans l'environnement de développement,
 docker login 10.9.2.21:8080 -u <user> -p <password>
@@ -89,7 +91,7 @@ docker pull 10.9.2.21:8080
 
 # Lancer le conteneur
 docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.baseurl=http://localhost:8080/ -Dagrold.sparql_endpoint=a" <tag>
-````
+```
 
 > [!NOTE]
 > À noter que l'image docker crée prend pour base l'image [bitnami/tomcat](https://hub.docker.com/r/bitnami/tomcat/). Cela veut dire que vous pouvez configurer l'image d'AgroLD comme celle de bitnami sur certain points nottament la configuration de l'utilisateur manager de tomcat.

--- a/agrold-javaweb/README.md
+++ b/agrold-javaweb/README.md
@@ -25,9 +25,8 @@ Le déploiement de l'application se fait premièrement avec des propriétés Jav
 
 |            Name            |                                                                    Description                                                                    |       Valeur par défaut       |
 | :------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------: |
-|       `agrold.name`        | Nom de l'archive et du contexte (le nom apparait après `agrold.baseurl` , par exemple si on met la valeur à `aldp` on a `https://someurl/agrold`) |            `aldp`             |
+|       `agrold.name`        | Nom de l'archive et du contexte `aldp` on a `https://<un domaine>/agrold`) |            `aldp`             |
 |    `agrold.description`    |                                                         Description affichée dans Tomcat                                                          |              :x:              |
-|      `agrold.baseurl`      |                                                              L'URL de base de l'app                                                               |   `http://localhost:8080/`    |
 |  `agrold.sparql_endpoint`  |                                                             Url de l'endpoint SPARQL                                                              | `http://sparql.southgreen.fr` |
 | `agrold.db_connection_url` |                                             Url de la base de données ex: `[host]:[port]/[db]?[opt]`                                              |         :x: (requis)          |
 |    `agrold.db_username`    |                                                         Utilisateur de la base de données                                                         |         :x: (requis)          |
@@ -90,7 +89,7 @@ docker login 10.9.2.21:8080 -u <user> -p <password>
 docker pull 10.9.2.21:8080
 
 # Lancer le conteneur
-docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.baseurl=http://localhost:8080/ -Dagrold.sparql_endpoint=a" <tag>
+docker run -p 8080:8080 -e CATALINA_OPTS="-Dagrold.db_connection_url=someurl -Dagrold.db_username=usr -Dagrold.db_password=pwd -Dagrold.sparql_endpoint=a" <tag>
 ```
 
 > [!NOTE]

--- a/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/Chart.yaml
@@ -9,7 +9,7 @@ annotations:
       image: docker.io/bitnami/tomcat:10.1.20-debian-12-r0
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 2.1.0
+appVersion: 2.1.1
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -46,4 +46,4 @@ name: agrold
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
 - https://github.com/SouthGreenPlatform/AgroLD_webapp
-version: 2.0.0
+version: 2.0.1

--- a/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
+++ b/agrold-javaweb/charts/agrold-javaweb/templates/_helpers.tpl
@@ -97,9 +97,9 @@ Return the proper CATALINA_OPTS value
 {{- define "tomcat.catalinaOpts" -}}
 {{- $agrold := include "tomcat.flattenIntoSysProperties" .Values.agroldProperties -}}
 {{- if .Values.metrics.jmx.enabled -}}
-{{- default "" (cat .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts (printf "-Dagrold.baseurl=%q" (ternary (print "https://" .Values.ingress.hostname) (print "http://" .Values.ingress.hostname) .Values.ingress.tls)) $agrold) | trim  -}}
+{{- default "" (cat .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts $agrold) | trim  -}}
 {{- else -}}
-{{- default "" (cat .Values.catalinaOpts (printf "-Dagrold.baseurl=%q" (ternary (print "https://" .Values.ingress.hostname) (print "http://" .Values.ingress.hostname) .Values.ingress.tls)) $agrold) | trim -}}
+{{- default "" (cat .Values.catalinaOpts $agrold) | trim -}}
 {{- end -}}
 {{- end -}}
 

--- a/agrold-javaweb/charts/agrold-javaweb/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/values.yaml
@@ -75,7 +75,7 @@ extraDeploy: []
 image:
   registry: ghcr.io
   repository: southgreenplatform/agrold
-  tag: 2.0.0
+  tag: 2.1.1
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/agrold-javaweb/charts/agrold-javaweb/values.yaml
+++ b/agrold-javaweb/charts/agrold-javaweb/values.yaml
@@ -8,8 +8,6 @@
 ##
 
 agroldProperties:
-  # The property below is set to ingress.hostname, set this value to override it
-  # baseurl: "http://agrold.org"
   db_connection_url: someurl
   db_username: user
   db_password: password

--- a/agrold-javaweb/charts/virtuoso/Chart.yaml
+++ b/agrold-javaweb/charts/virtuoso/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/agrold-javaweb/charts/virtuoso/templates/secrets.yaml
+++ b/agrold-javaweb/charts/virtuoso/templates/secrets.yaml
@@ -5,6 +5,6 @@ metadata:
   name: secrets-{{ $fullName }}
 type: Opaque
 data:
-  DAVPassword: {{ .Values.DAVPassword | b64enc | quote }}
-  DBAPassword: {{ .Values.DBAPassword | b64enc | quote }}
+  DAVPassword: {{ .Values.DAVPassword | default (randAlphaNum 32) | b64enc | quote }}
+  DBAPassword: {{ .Values.DBAPassword | default (randAlphaNum 32) | b64enc | quote }}
 

--- a/agrold-javaweb/charts/virtuoso/values.yaml
+++ b/agrold-javaweb/charts/virtuoso/values.yaml
@@ -89,10 +89,8 @@ initdb:
   enabled: true
   name: sparql-initdb
   kind: ConfigMap
-  data:
-    init.sh: |
-      #!/bin/bash
-      echo "Ready to go!"
+  data: {}
+
 
 persistence:
   enabled: true

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>agrold</groupId>
     <artifactId>agrold</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>war</packaging>
 
 

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -81,22 +81,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>4.0.0-M1</version>
+            <version>2.42</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>4.0.0-M1</version>
+            <version>2.42</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>4.0.0-M1</version>
+            <version>2.42</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>4.0.0-M1</version>
+            <version>2.42</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>

--- a/agrold-javaweb/pom.xml
+++ b/agrold-javaweb/pom.xml
@@ -45,17 +45,17 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.2.11</version>
+            <version>2.4.0-b180830.0359</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.2.11</version>
+            <version>4.0.5</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.2.11</version>
+            <version>4.0.5</version>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>
@@ -70,57 +70,57 @@
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
-            <version>6.0</version>
+            <version>8.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <version>2.26</version>
+            <version>4.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.26</version>
+            <version>4.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <version>2.26</version>
+            <version>4.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>2.26</version>
+            <version>4.0.0-M1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20180813</version>
+            <version>20240303</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.6</version>
+            <version>8.0.33</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.10.1</version>
         </dependency>
     </dependencies>
 

--- a/agrold-javaweb/src/main/java/agrold/ogust/config/MySQLProperties.java
+++ b/agrold-javaweb/src/main/java/agrold/ogust/config/MySQLProperties.java
@@ -30,7 +30,7 @@ public class MySQLProperties {
         /* prevent usage of constructor bcause it's a static class */
     }
     
-    
+    // TODO: Change how it is handled, this will be replaced by cookies since it is just for history purposes
     /**
      *
      * @return an ArrayList of String with the lines of the text in the same
@@ -39,13 +39,9 @@ public class MySQLProperties {
     public static List<String> readLoginConfigurations() {
         List<String> lines = new ArrayList<>();
         try {
-            String URL = System.getProperty("agrold.db_connection_url");
-            String usr = System.getProperty("agrold.db_username");
-            String pwd = System.getProperty("agrold.db_password");
-
-            if (URL == null) throw new NullPointerException("Missing system property: agrold.db_connection_url");
-            if (usr == null) throw new NullPointerException("Missing system property: agrold.db_username");
-            if (pwd == null) throw new NullPointerException("Missing system property: agrold.db_password");
+            String URL = System.getProperty("agrold.db_connection_url", "");
+            String usr = System.getProperty("agrold.db_username", "");
+            String pwd = System.getProperty("agrold.db_password", "");
 
             lines.add(URL);
             lines.add(usr);

--- a/agrold-javaweb/src/main/java/agrold/webservices/API.java
+++ b/agrold-javaweb/src/main/java/agrold/webservices/API.java
@@ -31,6 +31,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -95,7 +96,7 @@ public class API {
     @GET
     // @Consumes(MediaType.APPLICATION_JSON) // for "in body parameters"
     @Path("/customizable/{serviceLocalName}")
-    public Response genericGet(@PathParam("serviceLocalName") String serviceLocalName, @Context UriInfo uriInfo, @Context  HttpHeaders headers) throws IOException {        
+    public Response genericGet(@PathParam("serviceLocalName") String serviceLocalName, @Context UriInfo uriInfo, @Context HttpHeaders headers) throws IOException {        
         List<MediaType> mediaTypes = headers.getAcceptableMediaTypes();
         MediaType reponseMediaType = mediaTypes.get(0);
         if (reponseMediaType == null) {
@@ -103,7 +104,7 @@ public class API {
                     .entity("[AgroLD Web Services] - Format Error: The requested resource is not available in the format \"" + mediaTypes.get(0) + "\"")
                     .build();
         }
-        String content = CustomizableServicesManager.queryCustomizableService(serviceLocalName, uriInfo.getQueryParameters(), "get", reponseMediaType);
+        String content = CustomizableServicesManager.queryCustomizableService(serviceLocalName, uriInfo.getQueryParameters(), "get", reponseMediaType, headers.HOST);
         return buildResponse(content, reponseMediaType.toString());
     }
 
@@ -122,8 +123,8 @@ public class API {
     // generic web service for modifiables ones    
     @GET
     @Path("/webservices")
-    public Response getAPISpecification() throws IOException {
-        String content = CustomizableServicesManager.readAPISpecification(Utils.AGROLDAPIJSONURL);
+    public Response getAPISpecification(@HeaderParam("Host") String host) throws IOException {
+        String content = CustomizableServicesManager.readAPISpecification(Utils.AGROLDAPIJSONURL, host);
         return buildResponse(content, Utils.JSON);
     }
 
@@ -132,24 +133,24 @@ public class API {
     @DELETE
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/webservices")
-    public Response deleteService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod) throws IOException {        
-        String content = CustomizableServicesManager.deleteService(name, httpMethod); 
+    public Response deleteService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod, @HeaderParam("Host") String host) throws IOException {        
+        String content = CustomizableServicesManager.deleteService(name, httpMethod, host); 
         return buildResponse(content, MediaType.TEXT_PLAIN);
     }
 
     @RolesAllowed("ADMIN")
     @PUT
     @Path("/webservices")
-    public Response addService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod, InputStream specificationDataStream) throws IOException {       
-        String content = CustomizableServicesManager.addService(name, httpMethod, inputStream2String(specificationDataStream));
+    public Response addService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod, InputStream specificationDataStream, @HeaderParam("Host") String host) throws IOException {       
+        String content = CustomizableServicesManager.addService(name, httpMethod, inputStream2String(specificationDataStream), host);
         return buildResponse(content, MediaType.TEXT_PLAIN);
     }
 
     @RolesAllowed("ADMIN")
     @POST
     @Path("/webservices")
-    public Response updateService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod, InputStream specificationDataStream) throws IOException {
-        String content = CustomizableServicesManager.updateService(name, httpMethod, inputStream2String(specificationDataStream));
+    public Response updateService(@QueryParam("name") String name, @QueryParam("httpMethod") String httpMethod, InputStream specificationDataStream, @HeaderParam("Host") String host) throws IOException {
+        String content = CustomizableServicesManager.updateService(name, httpMethod, inputStream2String(specificationDataStream), host);
         return buildResponse(content, MediaType.TEXT_PLAIN);
     }
 

--- a/agrold-javaweb/src/main/java/agrold/webservices/BasicAuthenticationFilter.java
+++ b/agrold-javaweb/src/main/java/agrold/webservices/BasicAuthenticationFilter.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.Base64;
 
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
@@ -22,7 +23,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
-import org.glassfish.jersey.internal.util.Base64;
+// import org.glassfish.jersey.internal.util.Base64;
 
 /**
  * This filter verify the access permissions for a user based on username and
@@ -67,7 +68,7 @@ public class BasicAuthenticationFilter implements javax.ws.rs.container.Containe
                 final String encodedUserPassword = authorization.get(0).replaceFirst(AUTHENTICATION_SCHEME + " ", "");
 
                 //Decode username and password
-                String usernameAndPassword = new String(Base64.decode(encodedUserPassword.getBytes()));;
+                String usernameAndPassword = new String(Base64.getDecoder().decode(encodedUserPassword.getBytes()));;
 
                 //Split username and password tokens
                 final StringTokenizer tokenizer = new StringTokenizer(usernameAndPassword, ":");

--- a/agrold-javaweb/src/main/java/agrold/webservices/dao/CustomizableServicesManager.java
+++ b/agrold-javaweb/src/main/java/agrold/webservices/dao/CustomizableServicesManager.java
@@ -28,7 +28,7 @@ public class CustomizableServicesManager {
     /*public static String validateName(String name) {
         
     }*/
-    public static String readAPISpecification(String apiSpecificationPath) {
+    public static String readAPISpecification(String apiSpecificationPath, String host) {
         //JSON parser object to parse read file        
         JSONObject jsonObj = null;
         try (FileReader reader = new FileReader(apiSpecificationPath)) {
@@ -40,9 +40,9 @@ public class CustomizableServicesManager {
             JSONObject tagObj = new JSONObject();
 
             // Host only has hostname and port, meaning no protocol
-            String strippedUrl = System.getProperty("agrold.baseurl", "localhost:8080").replaceAll("http://", "").replaceAll("https://", "");
+            String strippedUrl = host.replaceAll("http://", "").replaceAll("https://", "");
 
-            // here we will fill the host property defined by the system property agrold.baseurl and agrold.name
+            // here we will fill the host property defined by the hosts from incoming requests & the system property agrold.name
             jsonObj.put("host", strippedUrl);
 
             jsonObj.put("basePath", "/" + System.getProperty("agrold.name", "aldp") + "/api");
@@ -77,8 +77,8 @@ public class CustomizableServicesManager {
      * @param webServiceSpecification : a JSON object with the method as key
      * @return the confirmation message
      */
-    public static String addService(String name, String httpMethod, String webServiceSpecification) {
-        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL));
+    public static String addService(String name, String httpMethod, String webServiceSpecification, String host) {
+        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL, host));
         JSONObject newServiceSpec = new JSONObject();
         String sparqlPattern = "get";
         newServiceSpec.put(httpMethod, new JSONObject(webServiceSpecification));
@@ -90,8 +90,8 @@ public class CustomizableServicesManager {
         return "The service /api/customizable/" + name + " has been created!";
     }
 
-    public static String deleteService(String name, String httpMethod) {
-        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL));
+    public static String deleteService(String name, String httpMethod, String host) {
+        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL, host));
         String servicePath = PATH_FIXED_PART + name.replaceAll("\\s+", "");
         if (apiSpecification.getJSONObject("paths").has(servicePath)) {
             apiSpecification.getJSONObject("paths").remove(servicePath);
@@ -101,8 +101,8 @@ public class CustomizableServicesManager {
         return "The service /api/customizable/" + name + " has been deleted!";
     }
 
-    public static String updateService(String name, String httpMethod, String webServiceSpecification) {
-        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL));
+    public static String updateService(String name, String httpMethod, String webServiceSpecification, String host) {
+        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL, host));
         JSONObject serviceNewSpec = new JSONObject(webServiceSpecification);
         //System.out.println(newServiceSpec.toString());
         String servicePath = PATH_FIXED_PART + name.replaceAll("\\s+", "");
@@ -120,8 +120,8 @@ public class CustomizableServicesManager {
         //System.out.println(apiSpecification.toString());
     }
 
-    public static String queryCustomizableService(String serviceLocalName, MultivaluedMap<String, String> queryParams, String httpMethod, MediaType reponseMediaType) throws IOException {
-        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL));
+    public static String queryCustomizableService(String serviceLocalName, MultivaluedMap<String, String> queryParams, String httpMethod, MediaType reponseMediaType, String host) throws IOException {
+        JSONObject apiSpecification = new JSONObject(readAPISpecification(Utils.AGROLDAPIJSONURL, host));
         String servicePath = PATH_FIXED_PART + serviceLocalName.replaceAll("\\s+", "");
         JSONObject serviceCurrentSpec = apiSpecification.getJSONObject("paths").getJSONObject(servicePath);
         if (serviceCurrentSpec != null) {            

--- a/agrold-javaweb/src/main/webapp/config/config.js
+++ b/agrold-javaweb/src/main/webapp/config/config.js
@@ -1,18 +1,4 @@
-
-//Fuses all parameters into a url
-function buildUrl(...url) {
-    return url.reduce((acc, val) => {
-        if (acc.endsWith('/') && val.startsWith('/'))
-            return acc + val.substring(1);
-        else if (acc.endsWith('/') || val.startsWith('/'))
-            return acc + val;
-        else return acc + '/' + val;
-    })
-}
-
-//WEBAPPURL="http://agrold.southgreen.fr/agrold";
-CONTEXT= system_context ?? "aldp";
-WEBAPPURL= buildUrl(( system_baseurl ?? "http://127.0.0.1:8080/" ),  CONTEXT);
+WEBAPPURL= "/" + (system_context ?? "aldp")
 
 // still constant in :
 // /Users/zadmin/agrold/git/AgroLD/agrold/src/main/webapp/bc_sparqleditor.jsp
@@ -26,11 +12,11 @@ SPARQLENDPOINTURL= system_sparqlendpoint ?? "http://sparql.southgreen.fr";
 // WEB-INF/Account/General/AJAX/Admin/_USER_FULL_DATA_LOADER.jsp
 // WEB-INF/Account/General/AJAX/History/QuickSearchList.jsp 
 // /src/main/webapp/quicksearch.jsp
-FACETEDURL="http://agrold.southgreen.fr/fct"; 
+FACETEDURL="http://agrold.southgreen.fr/fct"; //TODO
 
 //AGROLDAPIJSONURL=WEBAPPURL + "/config/agrold-api.json";
 //AGROLDAPIJSONURL=WEBAPPURL + "/api/agrold-api-specification.json";
-AGROLDAPIJSONURL= buildUrl(WEBAPPURL, "api/webservices");
+AGROLDAPIJSONURL= WEBAPPURL + "/api/webservices";
 
 
 // Advanced search default format to query the web services

--- a/agrold-javaweb/src/main/webapp/includes.jsp
+++ b/agrold-javaweb/src/main/webapp/includes.jsp
@@ -37,7 +37,6 @@
     }
 
     const system_context = parseJsp('<%= System.getProperty("agrold.name", "aldp") %>')
-    const system_baseurl = parseJsp('<%= System.getProperty("agrold.baseurl", "http://localhost:8080") %>')
     const system_sparqlendpoint = parseJsp('<%= System.getProperty("agrold.sparql_endpoint", "http://sparql.southgreen.fr") %>')
 </script>
 <script type="text/javascript" src="config/config.js"></script>


### PR DESCRIPTION
- Bump versions of dependencies, JDK and tomcat
- Remove the need of ``agrold.baseurl``
- Virtuoso now generates random password in kube secret (instead the container doing it itself)  